### PR TITLE
TRestGeant4Event::GetPositionDeviationInVolume new method added

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ build:
     - git submodule init source/libraries/geant4
     - git submodule update source/libraries/geant4
     - cd source/libraries/geant4/
-    - git checkout master
+    - git checkout ${CI_COMMIT_BRANCH}
     - cd ../../../
     - mkdir build
     - cd build

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -202,9 +202,9 @@ class TRestGeant4Event : public TRestEvent {
         return "Not defined";
     }
 
-    TVector3 GetPrimaryEventDirection(int n) { return fPrimaryEventDirection[n]; }
+    TVector3 GetPrimaryEventDirection(Int_t n = 0) { return fPrimaryEventDirection[n]; }
     TVector3 GetPrimaryEventOrigin() { return fPrimaryEventOrigin; }
-    Double_t GetPrimaryEventEnergy(int n) { return fPrimaryEventEnergy[n]; }
+    Double_t GetPrimaryEventEnergy(Int_t n = 0) { return fPrimaryEventEnergy[n]; }
 
     Int_t GetNumberOfHits(Int_t volID = -1);
     Int_t GetNumberOfTracks() { return fNTracks; }
@@ -223,8 +223,10 @@ class TRestGeant4Event : public TRestEvent {
     TVector3 GetMeanPositionInVolume(Int_t volID);
     TVector3 GetFirstPositionInVolume(Int_t volID);
     TVector3 GetLastPositionInVolume(Int_t volID);
+    TVector3 GetPositionDeviationInVolume(Int_t volID);
 
     TRestHits GetHits(Int_t volID = -1);
+    TRestHits GetHitsInVolume(Int_t volID) { return GetHits(volID); }
 
     Int_t GetNumberOfTracksForParticle(TString parName);
     Int_t GetEnergyDepositedByParticle(TString parName);

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -153,6 +153,36 @@ TVector3 TRestGeant4Event::GetMeanPositionInVolume(Int_t volID) {
 }
 
 ///////////////////////////////////////////////
+/// \brief A method that gets the standard deviation from the hits happening at a
+/// particular volumeId inside the geometry.
+///
+/// \param volID Int_t specifying volume ID
+///
+TVector3 TRestGeant4Event::GetPositionDeviationInVolume(Int_t volID) {
+    TVector3 meanPos = this->GetMeanPositionInVolume(volID);
+
+    Double_t nan = TMath::QuietNaN();
+    if (meanPos == TVector3(nan, nan, nan)) return TVector3(nan, nan, nan);
+
+    TRestHits hitsInVolume = GetHitsInVolume(volID);
+
+    Double_t edep = 0;
+    TVector3 deviation = TVector3(0, 0, 0);
+
+    for (int n = 0; n < hitsInVolume.GetNumberOfHits(); n++) {
+        Double_t en = hitsInVolume.GetEnergy(n);
+        TVector3 diff = meanPos - hitsInVolume.GetPosition(n);
+        diff.SetXYZ(diff.X() * diff.X(), diff.Y() * diff.Y(), diff.Z() * diff.Z());
+
+        deviation = deviation + en * diff;
+
+        edep += en;
+    }
+    deviation = (1. / edep) * deviation;
+    return deviation;
+}
+
+///////////////////////////////////////////////
 /// \brief Function to get the position (TVector3) of the first track that deposits energy in specified
 /// volume. If no hit is found for the volume, returns `TVector3(nan, nan, nan)` vector.
 ///


### PR DESCRIPTION
I added a method that returns the standard deviation of the hits position in a particular volume. The X,Y,Z deviations are returned inside a TVector3.