### PR TITLE
Minor pipeline updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
   - deploy
 
 before_script:
-  - export USER="detector"
+  - export USER="geant4"
   - pwd
   - echo $CI_SERVER_HOST
   - echo $CRONJOB


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/Author/jgalan/blue) ![1](https://badgen.net/badge/Size/1/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/jgalan-minor-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/jgalan-minor-fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just a minor pipeline update. Now when GitLab cronjob executes the pipeline it will execute `clang-format` + all other jobs.

Before, it was executing only `clang-format`, and it might hide a previous pipeline failing.