### PR TITLE
Refactoring imports / comments, fixed compilation issue with ROOT 6.25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.vs*
+*build*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
-#image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-22-08_Geant4v10.4.2
-image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-22-08_Geant4v10.4.3
+image: lobis/root-geant4-garfieldpp:cxx14_ROOTv6-25-01_Geant4v10.4.3
 
 stages:
   - pre-build

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -23,8 +23,7 @@
 #ifndef RestCore_TRestGeant4AnalysisProcess
 #define RestCore_TRestGeant4AnalysisProcess
 
-#include <TRestEventProcess.h>
-
+#include "TRestEventProcess.h"
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
 

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -23,10 +23,10 @@
 #ifndef RestCore_TRestGeant4AnalysisProcess
 #define RestCore_TRestGeant4AnalysisProcess
 
-#include <TRestGeant4Event.h>
-#include <TRestGeant4Metadata.h>
+#include <TRestEventProcess.h>
 
-#include "TRestEventProcess.h"
+#include "TRestGeant4Event.h"
+#include "TRestGeant4Metadata.h"
 
 //! A pure analysis process to extract information from a TRestGeant4Event
 class TRestGeant4AnalysisProcess : public TRestEventProcess {

--- a/inc/TRestGeant4BiasingVolume.h
+++ b/inc/TRestGeant4BiasingVolume.h
@@ -16,10 +16,11 @@
 #ifndef RestCore_TRestGeant4BiasingVolume
 #define RestCore_TRestGeant4BiasingVolume
 
-#include <iostream>
+#include <TObject.h>
+#include <TString.h>
+#include <TVector3.h>
 
-#include "TObject.h"
-#include "TVector3.h"
+#include <iostream>
 
 class TRestGeant4BiasingVolume : public TObject {
    protected:

--- a/inc/TRestGeant4BlobAnalysisProcess.h
+++ b/inc/TRestGeant4BlobAnalysisProcess.h
@@ -12,14 +12,13 @@
 #ifndef RestCore_TRestGeant4BlobAnalysisProcess
 #define RestCore_TRestGeant4BlobAnalysisProcess
 
-#include <TRestGeant4Event.h>
-#include <TRestGeant4Metadata.h>
+#include <TRestEventProcess.h>
 
-#include "TRestEventProcess.h"
+#include "TRestGeant4Event.h"
+#include "TRestGeant4Metadata.h"
 
 class TRestGeant4BlobAnalysisProcess : public TRestEventProcess {
    private:
-#ifndef __CINT__
     TRestGeant4Event* fG4Event;        //!
     TRestGeant4Metadata* fG4Metadata;  //!
 
@@ -28,7 +27,6 @@ class TRestGeant4BlobAnalysisProcess : public TRestEventProcess {
 
     std::vector<std::string> fQ2_Observables;  //!
     std::vector<double> fQ2_Radius;            //!
-#endif
 
     void InitFromConfigFile();
 

--- a/inc/TRestGeant4BlobAnalysisProcess.h
+++ b/inc/TRestGeant4BlobAnalysisProcess.h
@@ -12,8 +12,7 @@
 #ifndef RestCore_TRestGeant4BlobAnalysisProcess
 #define RestCore_TRestGeant4BlobAnalysisProcess
 
-#include <TRestEventProcess.h>
-
+#include "TRestEventProcess.h"
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
 

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -31,11 +31,12 @@
 #include <TMultiGraph.h>
 #include <TObject.h>
 #include <TRestEvent.h>
-#include <TRestGeant4Track.h>
 #include <TVector3.h>
 
 #include <iostream>
 #include <map>
+
+#include "TRestGeant4Track.h"
 
 /// An event class to store geant4 generated event information
 class TRestGeant4Event : public TRestEvent {
@@ -123,8 +124,6 @@ class TRestGeant4Event : public TRestEvent {
     }
 
    protected:
-#ifndef __CINT__
-
     // TODO These graphs should be placed in TRestTrack?
     // (following GetGraph implementation in TRestDetectorSignal)
     TGraph* fXZHitGraph;  //!
@@ -171,7 +170,6 @@ class TRestGeant4Event : public TRestEvent {
     TH1D* GetXHistogram(Int_t gridElement, std::vector<TString> optList);
     TH1D* GetYHistogram(Int_t gridElement, std::vector<TString> optList);
     TH1D* GetZHistogram(Int_t gridElement, std::vector<TString> optList);
-#endif
 
     TVector3 fPrimaryEventOrigin;
 

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -30,12 +30,12 @@
 #include <TLegend.h>
 #include <TMultiGraph.h>
 #include <TObject.h>
-#include <TRestEvent.h>
 #include <TVector3.h>
 
 #include <iostream>
 #include <map>
 
+#include "TRestEvent.h"
 #include "TRestGeant4Track.h"
 
 /// An event class to store geant4 generated event information

--- a/inc/TRestGeant4EventViewer.h
+++ b/inc/TRestGeant4EventViewer.h
@@ -15,7 +15,7 @@
 #ifndef RestCore_TRestGeant4EventViewer
 #define RestCore_TRestGeant4EventViewer
 
-#include "TRestEveEventViewer"
+#include "TRestEveEventViewer.h"
 #include "TRestGeant4Event.h"
 
 class TRestGeant4EventViewer : public TRestEveEventViewer {

--- a/inc/TRestGeant4EventViewer.h
+++ b/inc/TRestGeant4EventViewer.h
@@ -15,7 +15,7 @@
 #ifndef RestCore_TRestGeant4EventViewer
 #define RestCore_TRestGeant4EventViewer
 
-#include "TRestEveEventViewer.h"
+#include <TRestEveEventViewer.h>
 
 #include "TRestGeant4Event.h"
 

--- a/inc/TRestGeant4EventViewer.h
+++ b/inc/TRestGeant4EventViewer.h
@@ -15,8 +15,7 @@
 #ifndef RestCore_TRestGeant4EventViewer
 #define RestCore_TRestGeant4EventViewer
 
-#include <TRestEveEventViewer.h>
-
+#include "TRestEveEventViewer"
 #include "TRestGeant4Event.h"
 
 class TRestGeant4EventViewer : public TRestEveEventViewer {

--- a/inc/TRestGeant4Hits.h
+++ b/inc/TRestGeant4Hits.h
@@ -20,11 +20,10 @@
 
 #include <TArrayF.h>
 #include <TArrayI.h>
+#include <TObject.h>
 #include <TRestHits.h>
 
 #include <iostream>
-
-#include "TObject.h"
 
 class TRestGeant4Hits : public TRestHits {
    protected:

--- a/inc/TRestGeant4Hits.h
+++ b/inc/TRestGeant4Hits.h
@@ -21,9 +21,10 @@
 #include <TArrayF.h>
 #include <TArrayI.h>
 #include <TObject.h>
-#include <TRestHits.h>
 
 #include <iostream>
+
+#include "TRestHits.h"
 
 class TRestGeant4Hits : public TRestHits {
    protected:

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -24,7 +24,6 @@
 #define RestCore_TRestGeant4Metadata
 
 #include <TMath.h>
-#include <TRestMetadata.h>
 #include <TString.h>
 #include <TVector2.h>
 #include <TVector3.h>
@@ -39,6 +38,7 @@
 
 #include "TRestGeant4BiasingVolume.h"
 #include "TRestGeant4PrimaryGenerator.h"
+#include "TRestMetadata.h"
 
 //------------------------------------------------------------------------------------------------------------------------
 //

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -22,22 +22,23 @@
 
 #ifndef RestCore_TRestGeant4Metadata
 #define RestCore_TRestGeant4Metadata
+
+#include <TMath.h>
+#include <TRestMetadata.h>
+#include <TString.h>
+#include <TVector2.h>
+#include <TVector3.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <vector>
 
-#include <TMath.h>
-#include <TString.h>
-#include <TVector2.h>
-#include <TVector3.h>
-
-#include <TRestGeant4BiasingVolume.h>
-#include <TRestGeant4PrimaryGenerator.h>
-#include <TRestMetadata.h>
+#include "TRestGeant4BiasingVolume.h"
+#include "TRestGeant4PrimaryGenerator.h"
 
 //------------------------------------------------------------------------------------------------------------------------
 //

--- a/inc/TRestGeant4NeutronTaggingProcess.h
+++ b/inc/TRestGeant4NeutronTaggingProcess.h
@@ -23,10 +23,10 @@
 #ifndef RestCore_TRestGeant4NeutronTaggingProcess
 #define RestCore_TRestGeant4NeutronTaggingProcess
 
-#include <TRestGeant4Event.h>
-#include <TRestGeant4Metadata.h>
+#include <TRestEventProcess.h>
 
-#include "TRestEventProcess.h"
+#include "TRestGeant4Event.h"
+#include "TRestGeant4Metadata.h"
 
 class TRestGeant4NeutronTaggingProcess : public TRestEventProcess {
    private:

--- a/inc/TRestGeant4NeutronTaggingProcess.h
+++ b/inc/TRestGeant4NeutronTaggingProcess.h
@@ -23,8 +23,7 @@
 #ifndef RestCore_TRestGeant4NeutronTaggingProcess
 #define RestCore_TRestGeant4NeutronTaggingProcess
 
-#include <TRestEventProcess.h>
-
+#include "TRestEventProcess.h"
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
 

--- a/inc/TRestGeant4Particle.h
+++ b/inc/TRestGeant4Particle.h
@@ -16,11 +16,11 @@
 #ifndef RestCore_TRestGeant4Particle
 #define RestCore_TRestGeant4Particle
 
-#include <iostream>
-
+#include <TObject.h>
 #include <TString.h>
 #include <TVector3.h>
-#include "TObject.h"
+
+#include <iostream>
 
 class TRestGeant4Particle : public TObject {
    protected:

--- a/inc/TRestGeant4ParticleCollection.h
+++ b/inc/TRestGeant4ParticleCollection.h
@@ -16,11 +16,11 @@
 #ifndef RestCore_TRestGeant4ParticleCollection
 #define RestCore_TRestGeant4ParticleCollection
 
+#include <TObject.h>
+
 #include <iostream>
 
-#include "TObject.h"
-
-#include <TRestGeant4Particle.h>
+#include "TRestGeant4Particle.h"
 
 class TRestGeant4ParticleCollection : public TObject {
    protected:
@@ -43,7 +43,7 @@ class TRestGeant4ParticleCollection : public TObject {
     virtual void RemoveParticles() { fParticles.clear(); }
     virtual void AddParticle(TRestGeant4Particle ptcle) { fParticles.push_back(ptcle); }
 
-    // Construtor
+    // Constructor
     TRestGeant4ParticleCollection();
     // Destructor
     virtual ~TRestGeant4ParticleCollection();

--- a/inc/TRestGeant4ParticleCollectionDecay0.h
+++ b/inc/TRestGeant4ParticleCollectionDecay0.h
@@ -1,14 +1,14 @@
 #ifndef RestCore_TRestGeant4ParticleCollectionD0
 #define RestCore_TRestGeant4ParticleCollectionD0
 
-#include <TRestGeant4Particle.h>
+#include <TObject.h>
 #include <bxdecay0/decay0_generator.h>
 #include <bxdecay0/event.h>
 #include <bxdecay0/std_random.h>
 
 #include <iostream>
 
-#include "TObject.h"
+#include "TRestGeant4Particle.h"
 #include "TRestGeant4ParticleCollection.h"
 #include "TRestMetadata.h"
 

--- a/inc/TRestGeant4ParticleSource.h
+++ b/inc/TRestGeant4ParticleSource.h
@@ -17,14 +17,14 @@
 #ifndef RestCore_TRestGeant4ParticleSource
 #define RestCore_TRestGeant4ParticleSource
 
-#include <iostream>
-
+#include <TObject.h>
 #include <TString.h>
 #include <TVector2.h>
 #include <TVector3.h>
-#include "TObject.h"
-//
-#include <TRestGeant4Particle.h>
+
+#include <iostream>
+
+#include "TRestGeant4Particle.h"
 
 class TRestGeant4ParticleSource : public TRestGeant4Particle {
    protected:

--- a/inc/TRestGeant4PhysicsLists.h
+++ b/inc/TRestGeant4PhysicsLists.h
@@ -17,7 +17,6 @@
 #ifndef RestCore_TRestGeant4PhysicsLists
 #define RestCore_TRestGeant4PhysicsLists
 
-#include <TRestMetadata.h>
 #include <TString.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,6 +26,8 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
+
+#include "TRestMetadata.h"
 
 class TRestGeant4PhysicsLists : public TRestMetadata {
    private:

--- a/inc/TRestGeant4PhysicsLists.h
+++ b/inc/TRestGeant4PhysicsLists.h
@@ -17,17 +17,16 @@
 #ifndef RestCore_TRestGeant4PhysicsLists
 #define RestCore_TRestGeant4PhysicsLists
 
+#include <TRestMetadata.h>
+#include <TString.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <vector>
-
-#include <TString.h>
-
-#include <TRestMetadata.h>
 
 class TRestGeant4PhysicsLists : public TRestMetadata {
    private:

--- a/inc/TRestGeant4PrimaryGenerator.h
+++ b/inc/TRestGeant4PrimaryGenerator.h
@@ -16,14 +16,14 @@
 #ifndef RestCore_TRestGeant4PrimaryGenerator
 #define RestCore_TRestGeant4PrimaryGenerator
 
-#include <TRestGeant4ParticleCollection.h>
-#include <TRestGeant4ParticleSource.h>
+#include <TObject.h>
 #include <TString.h>
 #include <TVector3.h>
 
 #include <iostream>
 
-#include "TObject.h"
+#include "TRestGeant4ParticleCollection.h"
+#include "TRestGeant4ParticleSource.h"
 
 class TRestGeant4PrimaryGenerator : public TObject {
    protected:
@@ -37,7 +37,7 @@ class TRestGeant4PrimaryGenerator : public TObject {
     Int_t fNCollections;
 
     // storing particle generator information
-    // each entry --> one event template¡£
+    // each entry --> one event templateï¿½ï¿½
     // in restG4, we randomly pick the template from its entries and refresh
     // fSources
     std::vector<TRestGeant4ParticleCollection*> fParticleCollections;  //!

--- a/inc/TRestGeant4PrimaryGenerator.h
+++ b/inc/TRestGeant4PrimaryGenerator.h
@@ -37,9 +37,8 @@ class TRestGeant4PrimaryGenerator : public TObject {
     Int_t fNCollections;
 
     // storing particle generator information
-    // each entry --> one event template��
-    // in restG4, we randomly pick the template from its entries and refresh
-    // fSources
+    // each entry --> one event template
+    // in restG4, we randomly pick the template from its entries and refresh fSources
     std::vector<TRestGeant4ParticleCollection*> fParticleCollections;  //!
 
    public:
@@ -58,7 +57,7 @@ class TRestGeant4PrimaryGenerator : public TObject {
     /// accordingly. Used in TRestGeant4Metadata::ReadParticleCollection
     void UpdateSourcesFromParticleCollection(Int_t n);
 
-    // Construtor
+    // Constructor
     TRestGeant4PrimaryGenerator();
     // Destructor
     virtual ~TRestGeant4PrimaryGenerator();

--- a/inc/TRestGeant4Track.h
+++ b/inc/TRestGeant4Track.h
@@ -18,14 +18,14 @@
 
 #include <TArrayI.h>
 #include <TColor.h>
-#include <TRestGeant4Hits.h>
+#include <TObject.h>
 #include <TString.h>
 #include <TVector3.h>
 
 #include <iostream>
 #include <vector>
 
-#include "TObject.h"
+#include "TRestGeant4Hits.h"
 
 // Perhaps there might be need for a mother class TRestTrack (if there is future
 // need)

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -23,8 +23,7 @@
 #ifndef RestCore_TRestGeant4VetoAnalysisProcess
 #define RestCore_TRestGeant4VetoAnalysisProcess
 
-#include <TRestEventProcess.h>
-
+#include "TRestEventProcess.h"
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
 

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -23,10 +23,10 @@
 #ifndef RestCore_TRestGeant4VetoAnalysisProcess
 #define RestCore_TRestGeant4VetoAnalysisProcess
 
-#include <TRestGeant4Event.h>
-#include <TRestGeant4Metadata.h>
+#include <TRestEventProcess.h>
 
-#include "TRestEventProcess.h"
+#include "TRestGeant4Event.h"
+#include "TRestGeant4Metadata.h"
 
 class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
    private:

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -207,6 +207,7 @@
 /// <hr>
 ///
 #include "TRestGeant4AnalysisProcess.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4AnalysisProcess);

--- a/src/TRestGeant4BiasingVolume.cxx
+++ b/src/TRestGeant4BiasingVolume.cxx
@@ -16,19 +16,17 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4BiasingVolume.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4BiasingVolume)
-    //______________________________________________________________________________
+
     TRestGeant4BiasingVolume::TRestGeant4BiasingVolume() {
     fBiasingVolumeType = "virtualBox";
     // TRestGeant4BiasingVolume default constructor
 }
 
-//______________________________________________________________________________
-TRestGeant4BiasingVolume::~TRestGeant4BiasingVolume() {
-    // TRestGeant4BiasingVolume destructor
-}
+TRestGeant4BiasingVolume::~TRestGeant4BiasingVolume() = default;
 
 void TRestGeant4BiasingVolume::PrintBiasingVolume() {
     cout << "-----------------------------" << endl;

--- a/src/TRestGeant4BlobAnalysisProcess.cxx
+++ b/src/TRestGeant4BlobAnalysisProcess.cxx
@@ -14,38 +14,33 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4BlobAnalysisProcess.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4BlobAnalysisProcess);
-//______________________________________________________________________________
 TRestGeant4BlobAnalysisProcess::TRestGeant4BlobAnalysisProcess() { Initialize(); }
 
-//______________________________________________________________________________
 TRestGeant4BlobAnalysisProcess::TRestGeant4BlobAnalysisProcess(char* cfgFileName) {
     Initialize();
 
     if (LoadConfigFromFile(cfgFileName)) LoadDefaultConfig();
 }
 
-//______________________________________________________________________________
 TRestGeant4BlobAnalysisProcess::~TRestGeant4BlobAnalysisProcess() { delete fG4Event; }
 
 void TRestGeant4BlobAnalysisProcess::LoadDefaultConfig() { SetTitle("Default config"); }
 
-//______________________________________________________________________________
 void TRestGeant4BlobAnalysisProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
     fG4Event = new TRestGeant4Event();
-    /// fOutputG4Event = new TRestGeant4Event();
 }
 
 void TRestGeant4BlobAnalysisProcess::LoadConfig(std::string cfgFilename, std::string name) {
     if (LoadConfigFromFile(cfgFilename, name)) LoadDefaultConfig();
 }
 
-//______________________________________________________________________________
 void TRestGeant4BlobAnalysisProcess::InitProcess() {
     std::vector<string> fObservables;
     fObservables = TRestEventProcess::ReadObservables();
@@ -68,7 +63,6 @@ void TRestGeant4BlobAnalysisProcess::InitProcess() {
     fG4Metadata = GetMetadata<TRestGeant4Metadata>();
 }
 
-//______________________________________________________________________________
 TRestEvent* TRestGeant4BlobAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
     *fG4Event = *((TRestGeant4Event*)evInput);
 
@@ -186,7 +180,6 @@ TRestEvent* TRestGeant4BlobAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
     return fG4Event;
 }
 
-//______________________________________________________________________________
 void TRestGeant4BlobAnalysisProcess::EndProcess() {
     // Function to be executed once at the end of the process
     // (after all events have been processed)
@@ -196,5 +189,4 @@ void TRestGeant4BlobAnalysisProcess::EndProcess() {
     // TRestEventProcess::EndProcess();
 }
 
-//______________________________________________________________________________
 void TRestGeant4BlobAnalysisProcess::InitFromConfigFile() {}

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -1,6 +1,5 @@
 ///______________________________________________________________________________
 ///______________________________________________________________________________
-///______________________________________________________________________________
 ///
 ///
 ///             RESTSoft : Software for Rare Event Searches with TPCs
@@ -13,7 +12,8 @@
 ///                 Created as part of the conceptualization of existing REST
 ///                 software.
 ///                 Javier Galan
-///_______________________________________________________________________________
+///
+///______________________________________________________________________________
 
 #include "TRestGeant4Event.h"
 
@@ -26,7 +26,7 @@
 using namespace std;
 
 ClassImp(TRestGeant4Event);
-//______________________________________________________________________________
+
 TRestGeant4Event::TRestGeant4Event() {
     fNVolumes = 0;
     // TRestGeant4Event default constructor
@@ -34,10 +34,7 @@ TRestGeant4Event::TRestGeant4Event() {
     Initialize();
 }
 
-//______________________________________________________________________________
-TRestGeant4Event::~TRestGeant4Event() {
-    // TRestGeant4Event destructor
-}
+TRestGeant4Event::~TRestGeant4Event() = default;
 
 void TRestGeant4Event::Initialize() {
     TRestEvent::Initialize();

--- a/src/TRestGeant4EventViewer.cxx
+++ b/src/TRestGeant4EventViewer.cxx
@@ -1,6 +1,5 @@
 ///______________________________________________________________________________
 ///______________________________________________________________________________
-///______________________________________________________________________________
 ///
 ///
 ///             RESTSoft : Software for Rare Event Searches with TPCs
@@ -10,22 +9,21 @@
 ///             nov 2015:   First concept
 ///                 Viewer class for a TRestGeant4Event
 ///                 Javier Galan/JuanAn Garcia
+///
 ///_______________________________________________________________________________
 
 #include "TRestGeant4EventViewer.h"
+
 #include "TRestStringOutput.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4EventViewer);
-//______________________________________________________________________________
+
 TRestGeant4EventViewer::TRestGeant4EventViewer() { Initialize(); }
 
-//______________________________________________________________________________
-TRestGeant4EventViewer::~TRestGeant4EventViewer() {
-    // TRestGeant4EventViewer destructor
-}
+TRestGeant4EventViewer::~TRestGeant4EventViewer() = default;
 
-//______________________________________________________________________________
 void TRestGeant4EventViewer::Initialize() {
     fG4Event = new TRestGeant4Event();
     fEvent = fG4Event;
@@ -35,7 +33,7 @@ void TRestGeant4EventViewer::Initialize() {
 }
 
 void TRestGeant4EventViewer::DeleteCurrentEvent() {
-    // cout<<"Removing event"<<endl;
+    // cout << "Removing event" << endl;
 
     TRestEveEventViewer::DeleteCurrentEvent();
 

--- a/src/TRestGeant4Hits.cxx
+++ b/src/TRestGeant4Hits.cxx
@@ -1,6 +1,5 @@
 ///______________________________________________________________________________
 ///______________________________________________________________________________
-///______________________________________________________________________________
 ///
 ///
 ///             RESTSoft : Software for Rare Event Searches with TPCs
@@ -13,21 +12,18 @@
 ///                 Created as part of the conceptualization of existing REST
 ///                 software.
 ///                 J. Galan
+///
 ///_______________________________________________________________________________
 
 #include "TRestGeant4Hits.h"
 
 ClassImp(TRestGeant4Hits);
 
-//______________________________________________________________________________
 TRestGeant4Hits::TRestGeant4Hits() : TRestHits() {
     // TRestGeant4Hits default constructor
 }
 
-//______________________________________________________________________________
-TRestGeant4Hits::~TRestGeant4Hits() {
-    // TRestGeant4Hits destructor
-}
+TRestGeant4Hits::~TRestGeant4Hits() = default;
 
 void TRestGeant4Hits::AddG4Hit(TVector3 pos, Double_t en, Double_t hit_global_time, Int_t process,
                                Int_t volume, Double_t eKin, TVector3 momentumDirection) {

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -661,12 +661,14 @@
 ///
 /// <hr>
 ///
+
 #include "TRestGeant4Metadata.h"
-using namespace std;
 
 #include <TGeoManager.h>
 
 #include "TRestGDMLParser.h"
+
+using namespace std;
 
 namespace g4_metadata_parameters {
 string CleanString(string s) {
@@ -779,7 +781,7 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     if (ToUpper(seedstr) == "RANDOM" || ToUpper(seedstr) == "RAND" || ToUpper(seedstr) == "AUTO" ||
         seedstr == "0") {
         double* dd = new double();
-        fSeed = (uintptr_t)dd + (uintptr_t) this;
+        fSeed = (uintptr_t)dd + (uintptr_t)this;
         delete dd;
     } else {
         fSeed = (Long_t)StringToInteger(seedstr);

--- a/src/TRestGeant4NeutronTaggingProcess.cxx
+++ b/src/TRestGeant4NeutronTaggingProcess.cxx
@@ -86,6 +86,7 @@
 ///
 
 #include "TRestGeant4NeutronTaggingProcess.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4NeutronTaggingProcess);

--- a/src/TRestGeant4Particle.cxx
+++ b/src/TRestGeant4Particle.cxx
@@ -16,15 +16,11 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4Particle.h"
+
 using namespace std;
 
-ClassImp(TRestGeant4Particle)
-    //______________________________________________________________________________
-    TRestGeant4Particle::TRestGeant4Particle() {
-    // TRestGeant4Particle default constructor
-}
+ClassImp(TRestGeant4Particle);
 
-//______________________________________________________________________________
-TRestGeant4Particle::~TRestGeant4Particle() {
-    // TRestGeant4Particle destructor
-}
+TRestGeant4Particle::TRestGeant4Particle() = default;
+
+TRestGeant4Particle::~TRestGeant4Particle() = default;

--- a/src/TRestGeant4ParticleCollection.cxx
+++ b/src/TRestGeant4ParticleCollection.cxx
@@ -38,7 +38,7 @@ TRestGeant4ParticleCollection* TRestGeant4ParticleCollection::instantiate(string
         // in future we may add wrapper of generators: cry(for muon), pythia(for HEP), etc.
         model[0] = *REST_StringHelper::ToUpper(string(&model[0], 1)).c_str();
         TClass* c = TClass::GetClass(("TRestGeant4ParticleCollection" + model).c_str());
-        if (!c)  // this means we have the package installed
+        if (c)  // this means we have the package installed
         {
             return (TRestGeant4ParticleCollection*)c->New();
         } else {

--- a/src/TRestGeant4ParticleCollection.cxx
+++ b/src/TRestGeant4ParticleCollection.cxx
@@ -16,21 +16,18 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4ParticleCollection.h"
+
 #include "TClass.h"
 #include "TRestStringHelper.h"
 
-ClassImp(TRestGeant4ParticleCollection)
-    //______________________________________________________________________________
-    TRestGeant4ParticleCollection::TRestGeant4ParticleCollection() {
-    // TRestGeant4ParticleCollection default constructor
-}
+using namespace std;
 
-//______________________________________________________________________________
-TRestGeant4ParticleCollection::~TRestGeant4ParticleCollection() {
-    // TRestGeant4ParticleCollection destructor
-}
+ClassImp(TRestGeant4ParticleCollection);
 
-TRestGeant4ParticleCollection* TRestGeant4ParticleCollection::instantiate(std::string model) {
+TRestGeant4ParticleCollection::TRestGeant4ParticleCollection() = default;
+TRestGeant4ParticleCollection::~TRestGeant4ParticleCollection() = default;
+
+TRestGeant4ParticleCollection* TRestGeant4ParticleCollection::instantiate(string model) {
     if (model == "" || model == "geant4") {
         // use default generator
         return new TRestGeant4ParticleCollection();
@@ -39,15 +36,15 @@ TRestGeant4ParticleCollection* TRestGeant4ParticleCollection::instantiate(std::s
         // naming convension: TRestGeant4ParticleCollectionXXX
         // currently supported generator: decay0
         // in future we may add wrapper of generators: cry(for muon), pythia(for HEP), etc.
-        model[0] = *REST_StringHelper::ToUpper(std::string(&model[0], 1)).c_str();
+        model[0] = *REST_StringHelper::ToUpper(string(&model[0], 1)).c_str();
         TClass* c = TClass::GetClass(("TRestGeant4ParticleCollection" + model).c_str());
-        if (c != NULL)  // this means we have the package installed
+        if (!c)  // this means we have the package installed
         {
             return (TRestGeant4ParticleCollection*)c->New();
         } else {
-            std::cout << "REST ERROR! generator wrapper \"" << ("TRestGeant4ParticleCollection" + model)
-                      << "\" not found!" << std::endl;
+            cout << "REST ERROR! generator wrapper \"" << ("TRestGeant4ParticleCollection" + model)
+                 << "\" not found!" << endl;
         }
     }
-    return NULL;
+    return nullptr;
 }

--- a/src/TRestGeant4ParticleCollectionDecay0.cxx
+++ b/src/TRestGeant4ParticleCollectionDecay0.cxx
@@ -1,12 +1,13 @@
+
 #include "TRestGeant4ParticleCollectionDecay0.h"
 
-ClassImp(TRestGeant4ParticleCollectionDecay0)
+ClassImp(TRestGeant4ParticleCollectionDecay0);
 
-    void TRestGeant4ParticleCollectionDecay0::SetParticleModel(std::string modelstring) {
+void TRestGeant4ParticleCollectionDecay0::SetParticleModel(std::string modelstring) {
     cout << "Initializing decay0 model, seed: " << (uintptr_t)this << endl;
 
     fElement = StringToElement(modelstring);
-    fElementGlobal = NULL;
+    fElementGlobal = nullptr;
     InitFromConfigFile();
 }
 

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -15,30 +15,16 @@
 ///                 J. Galan
 ///_______________________________________________________________________________
 
-//#include "TFile.h"
-
 #include "TRestGeant4ParticleSource.h"
+
 #include "TRestStringOutput.h"
+
 using namespace std;
 
-// REST_Verbose_Level fLevel = REST_Essential;  //!
-////	TRestLeveledOutput(REST_Verbose_Level& vref, string _color =
-//// COLOR_RESET, string BorderOrHeader = "", REST_Display_Format style =
-//// kBorderedLeft)
-// TRestLeveledOutput<REST_Essential> metadata =
-//    TRestLeveledOutput<REST_Essential>(fLevel, COLOR_BOLDGREEN, "||",
-//                                       (REST_Display_Format)kBorderedMiddle);  //!
+ClassImp(TRestGeant4ParticleSource);
+TRestGeant4ParticleSource::TRestGeant4ParticleSource() = default;
 
-ClassImp(TRestGeant4ParticleSource)
-    //______________________________________________________________________________
-    TRestGeant4ParticleSource::TRestGeant4ParticleSource() {
-    // TRestGeant4ParticleSource default constructor
-}
-
-//______________________________________________________________________________
-TRestGeant4ParticleSource::~TRestGeant4ParticleSource() {
-    // TRestGeant4ParticleSource destructor
-}
+TRestGeant4ParticleSource::~TRestGeant4ParticleSource() = default;
 
 void TRestGeant4ParticleSource::PrintParticleSource() {
     metadata << "---------------------------------------" << endl;

--- a/src/TRestGeant4PhysicsLists.cxx
+++ b/src/TRestGeant4PhysicsLists.cxx
@@ -16,20 +16,19 @@
 ///                 Javier Galan
 ///_______________________________________________________________________________
 
+#include "TRestGeant4PhysicsLists.h"
+
 #include "TRestTools.h"
 
-#include "TRestGeant4PhysicsLists.h"
 using namespace std;
 
-ClassImp(TRestGeant4PhysicsLists)
-    //______________________________________________________________________________
-    TRestGeant4PhysicsLists::TRestGeant4PhysicsLists()
-    : TRestMetadata() {
+ClassImp(TRestGeant4PhysicsLists);
+
+TRestGeant4PhysicsLists::TRestGeant4PhysicsLists() : TRestMetadata() {
     // TRestGeant4PhysicsLists default constructor
     Initialize();
 }
 
-//______________________________________________________________________________
 TRestGeant4PhysicsLists::TRestGeant4PhysicsLists(char* cfgFileName, string name)
     : TRestMetadata(cfgFileName) {
     Initialize();
@@ -39,17 +38,13 @@ TRestGeant4PhysicsLists::TRestGeant4PhysicsLists(char* cfgFileName, string name)
     PrintMetadata();
 }
 
-//______________________________________________________________________________
-TRestGeant4PhysicsLists::~TRestGeant4PhysicsLists() {
-    // TRestGeant4PhysicsLists destructor
-}
+TRestGeant4PhysicsLists::~TRestGeant4PhysicsLists() = default;
 
 void TRestGeant4PhysicsLists::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 }
 
-//______________________________________________________________________________
 void TRestGeant4PhysicsLists::InitFromConfigFile() {
     this->Initialize();
 

--- a/src/TRestGeant4PrimaryGenerator.cxx
+++ b/src/TRestGeant4PrimaryGenerator.cxx
@@ -16,16 +16,16 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4PrimaryGenerator.h"
+
 using namespace std;
 
-ClassImp(TRestGeant4PrimaryGenerator)
-    //______________________________________________________________________________
-    TRestGeant4PrimaryGenerator::TRestGeant4PrimaryGenerator() {
+ClassImp(TRestGeant4PrimaryGenerator);
+
+TRestGeant4PrimaryGenerator::TRestGeant4PrimaryGenerator() {
     // TRestGeant4PrimaryGenerator default constructor
     Reset();
 }
 
-//______________________________________________________________________________
 TRestGeant4PrimaryGenerator::~TRestGeant4PrimaryGenerator() {}
 
 void TRestGeant4PrimaryGenerator::Reset() {

--- a/src/TRestGeant4Track.cxx
+++ b/src/TRestGeant4Track.cxx
@@ -16,18 +16,14 @@
 ///_______________________________________________________________________________
 
 #include "TRestGeant4Track.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4Track);
-//______________________________________________________________________________
-TRestGeant4Track::TRestGeant4Track() {
-    // TRestGeant4Track default constructor
-}
 
-//______________________________________________________________________________
-TRestGeant4Track::~TRestGeant4Track() {
-    // TRestGeant4Track destructor
-}
+TRestGeant4Track::TRestGeant4Track() = default;
+
+TRestGeant4Track::~TRestGeant4Track() = default;
 
 Int_t TRestGeant4Track::GetProcessID(TString pcsName) {
     Int_t id = -1;

--- a/src/TRestGeant4VetoAnalysisProcess.cxx
+++ b/src/TRestGeant4VetoAnalysisProcess.cxx
@@ -64,6 +64,7 @@
 ///
 
 #include "TRestGeant4VetoAnalysisProcess.h"
+
 using namespace std;
 
 ClassImp(TRestGeant4VetoAnalysisProcess);
@@ -90,12 +91,12 @@ void TRestGeant4VetoAnalysisProcess::LoadDefaultConfig() { SetTitle("Default con
 /// section name
 ///
 void TRestGeant4VetoAnalysisProcess::Initialize() {
-    fG4Metadata = NULL;
+    fG4Metadata = nullptr;
 
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputG4Event = NULL;
+    fInputG4Event = nullptr;
     fOutputG4Event = new TRestGeant4Event();
 }
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/Author/lobis/blue) ![120](https://badgen.net/badge/Size/120/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-refactoring/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-refactoring) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Issue with 6.25 was a single `#include <TString.h>`