### PR TITLE
Fixing library version 1.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
   - deploy
 
 before_script:
-  - export USER="detector"
+  - export USER="geant4"
   - pwd
   - echo $CI_SERVER_HOST
   - echo $CRONJOB

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ build:
   script:
     - echo "**${CI_PROJECT_DIR}**"
     - rm -rf ${CI_PROJECT_DIR}/install
-    - git clone --single-branch --branch development https://github.com/rest-for-physics/framework.git framework
+    - git clone --single-branch --branch master https://github.com/rest-for-physics/framework.git framework
     - cd framework
     - git submodule init source/libraries/geant4
     - git submodule update source/libraries/geant4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( LibraryVersion "1.2" )
+set( LibraryVersion "1.3" )
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
 if (${REST_DECAY0} MATCHES "ON")


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/Author/jgalan/blue) ![3](https://badgen.net/badge/Size/3/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/new_release/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/new_release) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is to fix a new release at geant4lib

Please, have a look at the changelog updates and edit if needed.

https://github.com/rest-for-physics/geant4lib/releases/tag/v1.3

I also fixed the release at restG4. However, since restG4 is a package there is no need to update any header version as we do in libraries, so there is no PR at restG4. I just create the release with the changelog. 

Please, @nkx could you have a look there? There is a couple of points that require your attention. Plz, give as much information as needed to understand the changes, and what it implies to users, such as RML updates required.

https://github.com/rest-for-physics/restG4/releases/tag/v1.3

Plz, edit the release changelog as needed