### PR TITLE
Better geometry management in metadata

### DIFF
--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -14,6 +14,8 @@ class G4VPhysicalVolume;
 
 class TRestGeant4Geometry : public TRestMetadata {
    private:
+    Bool_t fInitialized;  // flag to see if class has been initialized from Geant4
+
     TString fGdmlAbsolutePath;
     TString fGdmlContents;
 
@@ -41,10 +43,10 @@ class TRestGeant4Geometry : public TRestMetadata {
     std::map<TString, TVector3> fPhysicalToPositionInWorldMap;
 
     std::map<TString, Double_t> fPhysicalToStorageChanceMap;
-    const Double_t fDefaultStorageChance = 1.00;
+    constexpr static const Double_t fDefaultStorageChance = 1.00;
 
     std::map<TString, Double_t> fPhysicalToMaxStepSizeMap;  // units in mm
-    const Double_t fDefaultMaxStepSize = 0.05;
+    constexpr static const Double_t fDefaultMaxStepSize = 0.05;
 
    public:
     Bool_t IsActiveVolume(const TString&) const;
@@ -54,6 +56,10 @@ class TRestGeant4Geometry : public TRestMetadata {
     inline std::vector<TString> GetPhysicalVolumes() const { return fPhysicalVolumes; }
     inline std::vector<TString> GetLogicalVolumes() const { return fLogicalVolumes; }
     inline std::vector<TString> GetMaterials() const { return fMaterials; }
+
+    inline size_t GetNumberOfPhysicalVolumes() const { return fPhysicalVolumes.size(); }
+    inline size_t GetNumberOfLogicalVolumes() const { return fLogicalVolumes.size(); }
+    inline size_t GetNumberOfActiveVolumes() const { return fActiveVolumes.size(); }
 
     TVector3 GetPhysicalVolumePosition(const TString&) const;
 
@@ -67,21 +73,21 @@ class TRestGeant4Geometry : public TRestMetadata {
 
     TString GetPhysicalFromGeant4Physical(const TString&) const;
 
+    size_t GetActiveVolumeIndex(const TString&) const;
+    TString GetActiveVolumeFromIndex(size_t) const;
+
+    Double_t GetStorageChance(const TString&) const;
+    Double_t GetMaxStepSize(const TString&) const;
+
+   public:
+    void InsertActiveVolume(const TString& name, Double_t chance, Double_t maxStepSize);
+
    public:
     inline void InitFromConfigFile() override {}  // this class should not be initialized from rml
 
-    TRestGeant4Geometry() =
-        delete; /*
-                 * no default constructor, we only initialize this class from Geant4
-                 * world. This way we make sure this class is always filled with geometrical information
-                 */
+    TRestGeant4Geometry();
 
-    TRestGeant4Geometry(const G4VPhysicalVolume*); /*
-                                                    * Initialize from Geant4 world volume, preferably in
-                                                    * `DetectorConstruction`.
-                                                    * This method is implemented in the restG4 package since
-                                                    * it requires Geant4
-                                                    */
+    void InitializeFromGeant4World(const G4VPhysicalVolume*);  // Implemented in package that links to Geant4
 
    public:
     ClassDef(TRestGeant4Geometry, 1);

--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -91,17 +91,21 @@ class TRestGeant4Geometry : public TRestMetadata {
 
    public:
     void InsertActiveVolume(const TString& name, Double_t chance, Double_t maxStepSize);
+    void InsertSensitiveVolume(const TString& name);
 
     void LoadGdml(const TString& gdml);
 
    public:
-    inline void InitFromConfigFile() override {}  // this class should not be initialized from rml
-
     TRestGeant4Geometry();
 
     void InitializeFromGeant4World(const G4VPhysicalVolume*);  // Implemented in package that links to Geant4
 
     void BuildAssemblyLookupTable(const G4VPhysicalVolume*);
+
+    void LoadConfig(const TiXmlElement&);
+
+   private:
+    inline void InitFromConfigFile() override{};  // this class should not be initialized from rml
 
    public:
     ClassDef(TRestGeant4Geometry, 1);

--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -1,0 +1,90 @@
+/*
+ * Created by @lobis on 15/11/2021
+ *
+ * Class used to store geometry information. A single instance of this class will be in TRestGeant4Metadata.
+ * Having a separate class is due to the current size of TRestGeant4Metadata, this will help readability.
+ */
+
+#ifndef REST_TRESTGEANT4GEOMETRY_H
+#define REST_TRESTGEANT4GEOMETRY_H
+
+#include <TRestMetadata.h>
+
+class G4VPhysicalVolume;
+
+class TRestGeant4Geometry : public TRestMetadata {
+   private:
+    TString fGdmlAbsolutePath;
+    TString fGdmlContents;
+
+    std::vector<TString> fPhysicalVolumes; /*
+                                            * Sorted list of physical volumes as they appear in the GDML!
+                                            * It is important to be sorted, to solve the naming problem
+                                            * between TGeoManager and Geant4 with assembly volumes
+                                            */
+    std::vector<TString> fActiveVolumes;
+    std::vector<TString> fLogicalVolumes;
+    std::vector<TString> fMaterials;
+
+    std::map<TString, TString>
+        fGeant4PhysicalToPhysicalMap; /*
+                                       * maps TGeoManager volume name to Geant4 physical volume name,
+                                       * only makes sense when using assembly
+                                       */
+
+    std::map<TString, TString> fPhysicalToLogicalVolumeMap;
+    std::map<TString, std::vector<TString> > fLogicalToPhysicalMap;
+    // many physical volumes can point to one single logical
+
+    std::map<TString, TString> fLogicalToMaterialMap;
+
+    std::map<TString, TVector3> fPhysicalToPositionInWorldMap;
+
+    std::map<TString, Double_t> fPhysicalToStorageChanceMap;
+    const Double_t fDefaultStorageChance = 1.00;
+
+    std::map<TString, Double_t> fPhysicalToMaxStepSizeMap;  // units in mm
+    const Double_t fDefaultMaxStepSize = 0.05;
+
+   public:
+    Bool_t IsActiveVolume(const TString&) const;
+    Bool_t IsLogicalVolume(const TString&) const;
+    Bool_t IsPhysicalVolume(const TString&) const;
+
+    inline std::vector<TString> GetPhysicalVolumes() const { return fPhysicalVolumes; }
+    inline std::vector<TString> GetLogicalVolumes() const { return fLogicalVolumes; }
+    inline std::vector<TString> GetMaterials() const { return fMaterials; }
+
+    TVector3 GetPhysicalVolumePosition(const TString&) const;
+
+    std::vector<TString> GetAllPhysicalFromLogical(const TString&) const;
+    TString GetUniquePhysicalFromLogical(const TString&) const;
+
+    TString GetLogicalFromPhysical(const TString&) const;
+
+    TString GetMaterialFromLogical(const TString&) const;
+    TString GetMaterialFromPhysical(const TString&) const;
+
+    TString GetPhysicalFromGeant4Physical(const TString&) const;
+
+   public:
+    inline void InitFromConfigFile() override {}  // this class should not be initialized from rml
+
+    TRestGeant4Geometry() =
+        delete; /*
+                 * no default constructor, we only initialize this class from Geant4
+                 * world. This way we make sure this class is always filled with geometrical information
+                 */
+
+    TRestGeant4Geometry(const G4VPhysicalVolume*); /*
+                                                    * Initialize from Geant4 world volume, preferably in
+                                                    * `DetectorConstruction`.
+                                                    * This method is implemented in the restG4 package since
+                                                    * it requires Geant4
+                                                    */
+
+   public:
+    ClassDef(TRestGeant4Geometry, 1);
+};
+
+#endif  // REST_TRESTGEANT4GEOMETRY_H

--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -24,7 +24,9 @@ class TRestGeant4Geometry : public TRestMetadata {
                                             * It is important to be sorted, to solve the naming problem
                                             * between TGeoManager and Geant4 with assembly volumes
                                             */
+
     std::vector<TString> fActiveVolumes;
+    std::vector<TString> fSensitiveVolumes;
     std::vector<TString> fLogicalVolumes;
     std::vector<TString> fMaterials;
 
@@ -43,23 +45,27 @@ class TRestGeant4Geometry : public TRestMetadata {
     std::map<TString, TVector3> fPhysicalToPositionInWorldMap;
 
     std::map<TString, Double_t> fPhysicalToStorageChanceMap;
-    constexpr static const Double_t fDefaultStorageChance = 1.00;
+    // constexpr static const Double_t fDefaultStorageChance = 1.00;
 
     std::map<TString, Double_t> fPhysicalToMaxStepSizeMap;  // units in mm
-    constexpr static const Double_t fDefaultMaxStepSize = 0.05;
+    // constexpr static const Double_t fDefaultMaxStepSize = 0.05;
 
    public:
+    Bool_t IsSensitiveVolume(const TString&) const;
     Bool_t IsActiveVolume(const TString&) const;
     Bool_t IsLogicalVolume(const TString&) const;
     Bool_t IsPhysicalVolume(const TString&) const;
 
+    inline std::vector<TString> GetSensitiveVolumes() const { return fPhysicalVolumes; }
+    inline std::vector<TString> GetActiveVolumes() const { return fPhysicalVolumes; }
     inline std::vector<TString> GetPhysicalVolumes() const { return fPhysicalVolumes; }
     inline std::vector<TString> GetLogicalVolumes() const { return fLogicalVolumes; }
     inline std::vector<TString> GetMaterials() const { return fMaterials; }
 
+    inline size_t GetNumberOfSensitiveVolumes() const { return fSensitiveVolumes.size(); }
+    inline size_t GetNumberOfActiveVolumes() const { return fActiveVolumes.size(); }
     inline size_t GetNumberOfPhysicalVolumes() const { return fPhysicalVolumes.size(); }
     inline size_t GetNumberOfLogicalVolumes() const { return fLogicalVolumes.size(); }
-    inline size_t GetNumberOfActiveVolumes() const { return fActiveVolumes.size(); }
 
     TVector3 GetPhysicalVolumePosition(const TString&) const;
 
@@ -80,6 +86,7 @@ class TRestGeant4Geometry : public TRestMetadata {
     Double_t GetMaxStepSize(const TString&) const;
 
    public:
+    // Methods related to RML initialization
     void InsertActiveVolume(const TString& name, Double_t chance, Double_t maxStepSize);
 
    public:
@@ -88,6 +95,8 @@ class TRestGeant4Geometry : public TRestMetadata {
     TRestGeant4Geometry();
 
     void InitializeFromGeant4World(const G4VPhysicalVolume*);  // Implemented in package that links to Geant4
+
+    void BuildAssemblyLookupTable(const G4VPhysicalVolume*);
 
    public:
     ClassDef(TRestGeant4Geometry, 1);

--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -15,6 +15,7 @@ class G4VPhysicalVolume;
 class TRestGeant4Geometry : public TRestMetadata {
    private:
     Bool_t fInitialized;  // flag to see if class has been initialized from Geant4
+    Bool_t fAllVolumesActive = false;
 
     TString fGdmlAbsolutePath;
     TString fGdmlContents;
@@ -45,10 +46,10 @@ class TRestGeant4Geometry : public TRestMetadata {
     std::map<TString, TVector3> fPhysicalToPositionInWorldMap;
 
     std::map<TString, Double_t> fPhysicalToStorageChanceMap;
-    // constexpr static const Double_t fDefaultStorageChance = 1.00;
+    constexpr static const Double_t fDefaultStorageChance = 1.00;
 
     std::map<TString, Double_t> fPhysicalToMaxStepSizeMap;  // units in mm
-    // constexpr static const Double_t fDefaultMaxStepSize = 0.05;
+    constexpr static const Double_t fDefaultMaxStepSize = 0.05;
 
    public:
     Bool_t IsSensitiveVolume(const TString&) const;
@@ -85,9 +86,13 @@ class TRestGeant4Geometry : public TRestMetadata {
     Double_t GetStorageChance(const TString&) const;
     Double_t GetMaxStepSize(const TString&) const;
 
+    void PrintGeometryInfo() const;
+    inline void Print() const { PrintGeometryInfo(); }
+
    public:
-    // Methods related to RML initialization
     void InsertActiveVolume(const TString& name, Double_t chance, Double_t maxStepSize);
+
+    void LoadGdml(const TString& gdml);
 
    public:
     inline void InitFromConfigFile() override {}  // this class should not be initialized from rml

--- a/inc/TRestGeant4Geometry.h
+++ b/inc/TRestGeant4Geometry.h
@@ -20,6 +20,10 @@ class TRestGeant4Geometry : public TRestMetadata {
     TString fGdmlAbsolutePath;
     TString fGdmlContents;
 
+    std::set<TString> fGdmlPhysicalVolumes;  //!
+    std::set<TString> fGdmlLogicalVolumes;   //!
+    std::set<TString> fGdmlAssemblyVolumes;  //!
+
     std::vector<TString> fPhysicalVolumes; /*
                                             * Sorted list of physical volumes as they appear in the GDML!
                                             * It is important to be sorted, to solve the naming problem
@@ -102,7 +106,8 @@ class TRestGeant4Geometry : public TRestMetadata {
 
     void BuildAssemblyLookupTable(const G4VPhysicalVolume*);
 
-    void LoadConfig(const TiXmlElement&);
+    void LoadGdml(const TiXmlElement&, const TString& gdmlFilename);
+    void LoadVolumes(const TiXmlElement&);
 
    private:
     inline void InitFromConfigFile() override{};  // this class should not be initialized from rml

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -98,7 +98,8 @@ class TRestGeant4Metadata : public TRestMetadata {
     void ReadGenerator();
     void ReadParticleSource(TRestGeant4ParticleSource* src, TiXmlElement* sourceDefinition);
 
-    void ReadStorage();
+    void ReadStorage();  // TODO: Deprecate this
+    void ReadGeometry();
     void ReadBiasing();
 
     // void ReadEventDataFile(TString fName);

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -113,7 +113,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     TString fGeant4Version;
 
     /// Class that contains geometrical information
-    TRestGeant4Geometry* fGeometry;
+    TRestGeant4Geometry fGeometry;
 
     /// The local path to the GDML geometry
     TString fGeometryPath;  //!
@@ -224,6 +224,9 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     /// Returns the local path to the GDML geometry
     TString GetGeometryPath() { return fGeometryPath; }
+
+    /// Returns a reference to the geometry object with additional methods for geometry related stuff
+    TRestGeant4Geometry* GetGeometry() { return &fGeometry; }
 
     /// Returns the main filename of the GDML geometry
     TString Get_GDML_Filename() { return fGDML_Filename; }
@@ -376,7 +379,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// \brief Returns the probability per event to register (write to disk) hits in the
     /// storage volume with index n.
     inline Double_t GetStorageChance(size_t n) const {
-        return fGeometry->GetStorageChance(fGeometry->GetActiveVolumeFromIndex(n));
+        return fGeometry.GetStorageChance(fGeometry.GetActiveVolumeFromIndex(n));
     }
 
     /// Returns the probability per event to register (write to disk) hits in a
@@ -393,17 +396,17 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     /// \brief Returns the number of active volumes, or geometry volumes that have been
     /// selected for data storage.
-    size_t GetNumberOfActiveVolumes() { return fGeometry->GetNumberOfActiveVolumes(); }
+    size_t GetNumberOfActiveVolumes() { return fGeometry.GetNumberOfActiveVolumes(); }
 
     /// Returns a string with the name of the active volume with index n
-    TString GetActiveVolumeName(Int_t n) { return fGeometry->GetActiveVolumeFromIndex(n); }
+    TString GetActiveVolumeName(Int_t n) { return fGeometry.GetActiveVolumeFromIndex(n); }
 
     /// Returns the world magnetic field in Tesla
     TVector3 GetMagneticField() { return fMagneticField; }
 
-    Int_t GetActiveVolumeID(TString name);
+    Int_t GetActiveVolumeID(const TString& name);
 
-    Bool_t isVolumeStored(TString volName);
+    Bool_t isVolumeStored(const TString& volName);
 
     void SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep = 0);
 
@@ -414,6 +417,6 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     ~TRestGeant4Metadata();
 
-    ClassDef(TRestGeant4Metadata, 9);
+    ClassDef(TRestGeant4Metadata, 10);
 };
 #endif  // RestCore_TRestGeant4Metadata

--- a/src/TRestGeant4Geometry.cxx
+++ b/src/TRestGeant4Geometry.cxx
@@ -6,6 +6,15 @@
 
 using namespace std;
 
+Bool_t TRestGeant4Geometry::IsSensitiveVolume(const TString& inputPhysicalVolume) const {
+    for (const auto& volume : fSensitiveVolumes) {
+        if (inputPhysicalVolume.EqualTo(volume)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 Bool_t TRestGeant4Geometry::IsActiveVolume(const TString& inputPhysicalVolume) const {
     for (const auto& volume : fActiveVolumes) {
         if (inputPhysicalVolume.EqualTo(volume)) {
@@ -87,6 +96,7 @@ size_t TRestGeant4Geometry::GetActiveVolumeIndex(const TString& inputActiveVolum
             return i;
         }
     }
+    return -1;
 }
 
 Double_t TRestGeant4Geometry::GetStorageChance(const TString& inputPhysicalVolume) const {
@@ -99,9 +109,10 @@ Double_t TRestGeant4Geometry::GetMaxStepSize(const TString& inputPhysicalVolume)
 
 TString TRestGeant4Geometry::GetActiveVolumeFromIndex(size_t index) const { return fActiveVolumes[index]; }
 
-void TRestGeant4Geometry::InsertActiveVolume(const TString& name, Double_t chance = fDefaultStorageChance,
-                                             Double_t maxStepSize = fDefaultMaxStepSize) {
-    fActiveVolumes.emplace_back(name);
+void TRestGeant4Geometry::InsertActiveVolume(const TString& name, Double_t chance, Double_t maxStepSize) {
+    if (!IsActiveVolume(name)) {
+        fActiveVolumes.emplace_back(name);
+    }
     fPhysicalToStorageChanceMap[name] = chance;
     fPhysicalToMaxStepSizeMap[name] = maxStepSize;
 }

--- a/src/TRestGeant4Geometry.cxx
+++ b/src/TRestGeant4Geometry.cxx
@@ -1,0 +1,77 @@
+//
+// Created by lobis on 15/11/2021.
+//
+
+#include "TRestGeant4Geometry.h"
+
+using namespace std;
+
+Bool_t TRestGeant4Geometry::IsActiveVolume(const TString& inputPhysicalVolume) const {
+    for (const auto& volume : fActiveVolumes) {
+        if (inputPhysicalVolume.EqualTo(volume)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Bool_t TRestGeant4Geometry::IsPhysicalVolume(const TString& inputPhysicalVolume) const {
+    for (const auto& volume : fPhysicalVolumes) {
+        if (inputPhysicalVolume.EqualTo(volume)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Bool_t TRestGeant4Geometry::IsLogicalVolume(const TString& inputPhysicalVolume) const {
+    for (const auto& volume : fLogicalVolumes) {
+        if (inputPhysicalVolume.EqualTo(volume)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+TVector3 TRestGeant4Geometry::GetPhysicalVolumePosition(const TString& inputPhysicalVolume) const {
+    /*
+     * This method will throw exception if the requested volume does not exist, if not sure, check with
+     * `IsPhysicalVolume`
+     */
+    return fPhysicalToPositionInWorldMap.at(inputPhysicalVolume);
+}
+
+/// Attempts to return the unique physical volume associated with a given logical volume.
+/// Returns "" if not found
+TString TRestGeant4Geometry::GetUniquePhysicalFromLogical(const TString& inputLogicalVolume) const {
+    if (IsLogicalVolume(inputLogicalVolume)) {
+        auto physicalVolumes = fLogicalToPhysicalMap.at(inputLogicalVolume);
+        if (physicalVolumes.size() == 1) {
+            return physicalVolumes[0];
+        }
+    }
+    return "";
+}
+
+vector<TString> TRestGeant4Geometry::GetAllPhysicalFromLogical(const TString& inputLogicalVolume) const {
+    return fLogicalToPhysicalMap.at(inputLogicalVolume);
+}
+
+TString TRestGeant4Geometry::GetLogicalFromPhysical(const TString& inputPhysicalVolume) const {
+    return fPhysicalToLogicalVolumeMap.at(inputPhysicalVolume);
+}
+
+TString TRestGeant4Geometry::GetMaterialFromLogical(const TString& inputLogicalVolume) const {
+    return fLogicalToMaterialMap.at(inputLogicalVolume);
+}
+
+TString TRestGeant4Geometry::GetMaterialFromPhysical(const TString& inputPhysicalVolume) const {
+    return fLogicalToMaterialMap.at(GetLogicalFromPhysical(inputPhysicalVolume));
+}
+
+TString TRestGeant4Geometry::GetPhysicalFromGeant4Physical(const TString& inputGeant4PhysicalVolume) const {
+    if (fGeant4PhysicalToPhysicalMap.empty()) {
+        return inputGeant4PhysicalVolume;
+    }
+    return fGeant4PhysicalToPhysicalMap.at(inputGeant4PhysicalVolume);
+}

--- a/src/TRestGeant4Geometry.cxx
+++ b/src/TRestGeant4Geometry.cxx
@@ -130,8 +130,7 @@ void TRestGeant4Geometry::LoadGdml(const TString& gdml) {
 }
 
 void TRestGeant4Geometry::PrintGeometryInfo() const {
-    cout << "TRestGeant4Geometry::PrintGeometryInfo" << endl;
-    cout << "---> Total number of physical volumes: " << fPhysicalVolumes.size() << endl;
+    metadata << "TRestGeant4Geometry::PrintGeometryInfo ---> Total number of physical volumes: " << fPhysicalVolumes.size() << endl;
     for (const auto& volume : fPhysicalVolumes) {
         auto logicalVolumeName = fPhysicalToLogicalVolumeMap.at(volume);
         auto materialName = fLogicalToMaterialMap.at(logicalVolumeName);

--- a/src/TRestGeant4Geometry.cxx
+++ b/src/TRestGeant4Geometry.cxx
@@ -75,3 +75,35 @@ TString TRestGeant4Geometry::GetPhysicalFromGeant4Physical(const TString& inputG
     }
     return fGeant4PhysicalToPhysicalMap.at(inputGeant4PhysicalVolume);
 }
+
+size_t TRestGeant4Geometry::GetActiveVolumeIndex(const TString& inputActiveVolume) const {
+    if (!IsActiveVolume(inputActiveVolume)) {
+        cerr << "TRestGeant4Geometry::GetActiveVolumeIndex - " << inputActiveVolume
+             << " is not a valid active volume.";
+        exit(1);
+    }
+    for (int i = 0; i < fActiveVolumes.size(); i++) {
+        if (inputActiveVolume.EqualTo(fActiveVolumes[i])) {
+            return i;
+        }
+    }
+}
+
+Double_t TRestGeant4Geometry::GetStorageChance(const TString& inputPhysicalVolume) const {
+    return fPhysicalToStorageChanceMap.at(inputPhysicalVolume);
+}
+
+Double_t TRestGeant4Geometry::GetMaxStepSize(const TString& inputPhysicalVolume) const {
+    return fPhysicalToMaxStepSizeMap.at(inputPhysicalVolume);
+}
+
+TString TRestGeant4Geometry::GetActiveVolumeFromIndex(size_t index) const { return fActiveVolumes[index]; }
+
+void TRestGeant4Geometry::InsertActiveVolume(const TString& name, Double_t chance = fDefaultStorageChance,
+                                             Double_t maxStepSize = fDefaultMaxStepSize) {
+    fActiveVolumes.emplace_back(name);
+    fPhysicalToStorageChanceMap[name] = chance;
+    fPhysicalToMaxStepSizeMap[name] = maxStepSize;
+}
+
+TRestGeant4Geometry::TRestGeant4Geometry() : fInitialized(false) {}

--- a/src/TRestGeant4Geometry.cxx
+++ b/src/TRestGeant4Geometry.cxx
@@ -118,3 +118,24 @@ void TRestGeant4Geometry::InsertActiveVolume(const TString& name, Double_t chanc
 }
 
 TRestGeant4Geometry::TRestGeant4Geometry() : fInitialized(false) {}
+
+void TRestGeant4Geometry::LoadGdml(const TString& gdml) {
+    fGdmlAbsolutePath = gdml;
+    ifstream f(fGdmlAbsolutePath);
+    if (f) {
+        ostringstream ss;
+        ss << f.rdbuf();  // reading data
+        fGdmlContents = ss.str();
+    }
+}
+
+void TRestGeant4Geometry::PrintGeometryInfo() const {
+    cout << "TRestGeant4Geometry::PrintGeometryInfo" << endl;
+    cout << "---> Total number of physical volumes: " << fPhysicalVolumes.size() << endl;
+    for (const auto& volume : fPhysicalVolumes) {
+        auto logicalVolumeName = fPhysicalToLogicalVolumeMap.at(volume);
+        auto materialName = fLogicalToMaterialMap.at(logicalVolumeName);
+        metadata << "---> ---> physical volume: " << volume << " - logical: " << logicalVolumeName
+                 << " - material: " << materialName << endl;
+    }
+}

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1106,13 +1106,16 @@ void TRestGeant4Metadata::ReadStorage() {
         volumeDefinition = GetNextElement(volumeDefinition);
     }
 
+    /*
     // If the user didnt add explicitly any volume to the storage section we understand
     // the user wants to register all the volumes
-    if (GetNumberOfActiveVolumes() == 0)
+    if (GetNumberOfActiveVolumes() == 0) {
         for (auto& name : physicalVolumesSet) {
             SetActiveVolume(name, 1, defaultStep);
             info << "Automatically adding active volume: '" << name << "' with chance: " << 1 << endl;
         }
+    }
+     */
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -733,8 +733,6 @@ void TRestGeant4Metadata::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fChance.clear();
-    fActiveVolumes.clear();
     fBiasingVolumes.clear();
 
     fNBiasingVolumes = 0;
@@ -1503,11 +1501,10 @@ void TRestGeant4Metadata::PrintMetadata() {
 ///////////////////////////////////////////////
 /// \brief Returns the id of an active volume giving as parameter its name.
 Int_t TRestGeant4Metadata::GetActiveVolumeID(TString name) {
-    Int_t id;
-    for (id = 0; id < (Int_t)fActiveVolumes.size(); id++) {
-        if (fActiveVolumes[id] == name) return id;
+    if (!fGeometry->IsActiveVolume(name)) {
+        return -1;
     }
-    return -1;
+    return fGeometry->GetActiveVolumeIndex(name);
 }
 
 ///////////////////////////////////////////////
@@ -1524,10 +1521,8 @@ Int_t TRestGeant4Metadata::GetActiveVolumeID(TString name) {
 /// The aim of this parameter is to define control volumes. Usually the volume
 /// of interest will be always registered (chance=1).
 ///
-void TRestGeant4Metadata::SetActiveVolume(TString name, Double_t chance, Double_t maxStep) {
-    fActiveVolumes.push_back(name);
-    fChance.push_back(chance);
-    fMaxStepSize.push_back(maxStep);
+void TRestGeant4Metadata::SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep) {
+    fGeometry->InsertActiveVolume(name, chance, maxStep);
 }
 
 ///////////////////////////////////////////////
@@ -1544,24 +1539,21 @@ Bool_t TRestGeant4Metadata::isVolumeStored(TString volName) {
 ///////////////////////////////////////////////
 /// \brief Returns the probability of an active volume being stored
 ///
-Double_t TRestGeant4Metadata::GetStorageChance(TString vol) {
-    Int_t id;
-    for (id = 0; id < (Int_t)fActiveVolumes.size(); id++) {
-        if (fActiveVolumes[id] == vol) return fChance[id];
+Double_t TRestGeant4Metadata::GetStorageChance(const TString& vol) {
+    if (!fGeometry->IsActiveVolume(vol)) {
+        warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
+        return 0;
     }
-    warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
-
-    return 0;
+    return fGeometry->GetStorageChance(vol);
 }
 
 ///////////////////////////////////////////////
 /// \brief Returns the maximum step at a particular active volume
 ///
-Double_t TRestGeant4Metadata::GetMaxStepSize(TString vol) {
-    for (Int_t id = 0; id < (Int_t)fActiveVolumes.size(); id++) {
-        if (fActiveVolumes[id] == vol) return fMaxStepSize[id];
+Double_t TRestGeant4Metadata::GetMaxStepSize(const TString& vol) {
+    if (!fGeometry->IsActiveVolume(vol)) {
+        warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
+        return 0;
     }
-    warning << "TRestGeant4Metadata::GetMaxStepSize. Volume " << vol << " not found" << endl;
-
-    return 0;
+    return fGeometry->GetMaxStepSize(vol);
 }

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -796,7 +796,8 @@ void TRestGeant4Metadata::InitFromConfigFile() {
 
     ReadGenerator();
 
-    ReadStorage();
+    // ReadStorage();
+    ReadGeometry();
 
     ReadBiasing();
 
@@ -1116,6 +1117,15 @@ void TRestGeant4Metadata::ReadStorage() {
         }
     }
      */
+}
+
+void TRestGeant4Metadata::ReadGeometry() {
+    TiXmlElement* geometryDefinition = GetElement("TRestGeant4Geometry");
+    if (!geometryDefinition) {
+        warning << "'TRestGeant4Geometry' section not found in 'TRestGeant4Metadata'" << endl;
+        exit(1);
+    }
+    fGeometry.LoadConfig(*geometryDefinition);
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1125,7 +1125,8 @@ void TRestGeant4Metadata::ReadGeometry() {
         warning << "'TRestGeant4Geometry' section not found in 'TRestGeant4Metadata'" << endl;
         exit(1);
     }
-    fGeometry.LoadConfig(*geometryDefinition);
+    fGeometry.LoadGdml(*geometryDefinition, Get_GDML_Filename());
+    fGeometry.LoadVolumes(*geometryDefinition);
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1500,11 +1500,11 @@ void TRestGeant4Metadata::PrintMetadata() {
 
 ///////////////////////////////////////////////
 /// \brief Returns the id of an active volume giving as parameter its name.
-Int_t TRestGeant4Metadata::GetActiveVolumeID(TString name) {
-    if (!fGeometry->IsActiveVolume(name)) {
+Int_t TRestGeant4Metadata::GetActiveVolumeID(const TString& name) {
+    if (!fGeometry.IsActiveVolume(name)) {
         return -1;
     }
-    return fGeometry->GetActiveVolumeIndex(name);
+    return fGeometry.GetActiveVolumeIndex(name);
 }
 
 ///////////////////////////////////////////////
@@ -1522,38 +1522,35 @@ Int_t TRestGeant4Metadata::GetActiveVolumeID(TString name) {
 /// of interest will be always registered (chance=1).
 ///
 void TRestGeant4Metadata::SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep) {
-    fGeometry->InsertActiveVolume(name, chance, maxStep);
+    fGeometry.InsertActiveVolume(name, chance, maxStep);
 }
 
 ///////////////////////////////////////////////
 /// \brief Returns true if the volume named *volName* has been registered for
 /// data storage.
 ///
-Bool_t TRestGeant4Metadata::isVolumeStored(TString volName) {
-    for (int n = 0; n < GetNumberOfActiveVolumes(); n++)
-        if (GetActiveVolumeName(n) == volName) return true;
-
-    return false;
+Bool_t TRestGeant4Metadata::isVolumeStored(const TString& volName) {
+    return fGeometry.IsActiveVolume(volName);
 }
 
 ///////////////////////////////////////////////
 /// \brief Returns the probability of an active volume being stored
 ///
 Double_t TRestGeant4Metadata::GetStorageChance(const TString& vol) {
-    if (!fGeometry->IsActiveVolume(vol)) {
+    if (!fGeometry.IsActiveVolume(vol)) {
         warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
         return 0;
     }
-    return fGeometry->GetStorageChance(vol);
+    return fGeometry.GetStorageChance(vol);
 }
 
 ///////////////////////////////////////////////
 /// \brief Returns the maximum step at a particular active volume
 ///
 Double_t TRestGeant4Metadata::GetMaxStepSize(const TString& vol) {
-    if (!fGeometry->IsActiveVolume(vol)) {
+    if (!fGeometry.IsActiveVolume(vol)) {
         warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
         return 0;
     }
-    return fGeometry->GetMaxStepSize(vol);
+    return fGeometry.GetMaxStepSize(vol);
 }


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![lobis](https://badgen.net/badge/Author/lobis/blue) ![396](https://badgen.net/badge/Size/396/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/dev-lobis-geometry/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/dev-lobis-geometry)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I made a new class `TRestGeant4Geometry` to manage geometry related stuff and remove complexity from `TRestGeant4Metadata`.

I have also added "support" for assembly volumes generating a lookup table to get a human readable volume name for an assembly physical volume.

This PR should be merged only after restG4 pipeline gives a green light. [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/dev-lobis-geometry/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/dev-lobis-geometry) 

I convert the PR to draft to avoid merging before fulfilling such condition.