### PR TITLE
TRestGeant4AnalysisProcess. Added thetaPrimary and phiPrimary angles …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( LibraryVersion "1.5" )
+set( LibraryVersion "1.6" )
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
 if (${REST_DECAY0} MATCHES "ON")

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -143,6 +143,9 @@
 /// * **zDirectionPrimary**: z-component defining the momentum direction
 /// of the primary event generated.
 ///
+/// * **thetaPrimary**: polar angle of the primary generated particle.
+/// * **phiPrimary**: azimuth angle of the primary generated particle.
+///
 /// * **energyPrimary**: energy of the primary event generated.
 ///
 /// The following code ilustrates the addition of a primary event
@@ -298,6 +301,7 @@ void TRestGeant4AnalysisProcess::InitProcess() {
         fObservables.push_back("PerProcessNeutronElastic");
     }
     for (unsigned int i = 0; i < fObservables.size(); i++) {
+        cout << "fObservables[" << i << "] = " << fObservables[i] << endl;
         if (fObservables[i].find("VolumeEDep") != string::npos) {
             TString volName = fObservables[i].substr(0, fObservables[i].length() - 10).c_str();
 
@@ -443,6 +447,10 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* evInput) {
 
     Double_t zDirection = fOutputG4Event->GetPrimaryEventDirection(0).Z();
     SetObservableValue((string) "zDirectionPrimary", zDirection);
+
+    TVector3 v(xDirection, yDirection, zDirection);
+    SetObservableValue((string) "thetaPrimary", v.Theta());
+    SetObservableValue((string) "phiPrimary", v.Phi());
 
     Double_t energyPrimary = fOutputG4Event->GetPrimaryEventEnergy(0);
     SetObservableValue((string) "energyPrimary", energyPrimary);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/Author/jgalan/blue) ![9](https://badgen.net/badge/Size/9/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/alphas_example/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/alphas_example)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is connected to rest-for-physics/framework#122

- It adds two new observables (`phiPrimary` and `thetaPrimary`) identifying the angles of the primary particle.