### PR TITLE
Made many methods `const`, GetTrack, GetHits methods now return a constant reference

### DIFF
--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -165,8 +165,8 @@ class TRestGeant4Event : public TRestEvent {
     TRestHits GetHits(Int_t volID = -1) const;
     inline TRestHits GetHitsInVolume(Int_t volID) const { return GetHits(volID); }
 
-    Int_t GetNumberOfTracksForParticle(TString parName) const;
-    Int_t GetEnergyDepositedByParticle(TString parName) const;
+    Int_t GetNumberOfTracksForParticle(const TString& parName) const;
+    Int_t GetEnergyDepositedByParticle(const TString& parName) const;
 
     inline Double_t GetEnergyInSensitiveFromProcessPhoto() {
         if (!PerProcessEnergyInitFlag) {
@@ -229,9 +229,9 @@ class TRestGeant4Event : public TRestEvent {
         return PerProcessEnergyInSensitive["neutron_elastic"];
     }
 
-    inline void SetPrimaryEventOrigin(TVector3 pos) { fPrimaryEventOrigin = pos; }
-    inline void SetPrimaryEventDirection(TVector3 dir) { fPrimaryEventDirection.push_back(dir); }
-    inline void SetPrimaryEventParticleName(TString pName) { fPrimaryParticleName.push_back(pName); }
+    inline void SetPrimaryEventOrigin(const TVector3& pos) { fPrimaryEventOrigin = pos; }
+    inline void SetPrimaryEventDirection(const TVector3& dir) { fPrimaryEventDirection.push_back(dir); }
+    inline void SetPrimaryEventParticleName(const TString& pName) { fPrimaryParticleName.push_back(pName); }
     inline void SetPrimaryEventEnergy(Double_t en) { fPrimaryEventEnergy.push_back(en); }
     inline void ActivateVolumeForStorage(Int_t n) { fVolumeStored[n] = 1; }
     inline void DisableVolumeForStorage(Int_t n) { fVolumeStored[n] = 0; }
@@ -430,8 +430,8 @@ class TRestGeant4Event : public TRestEvent {
     void PrintActiveVolumes() const;
     void PrintEvent(int maxTracks = 0, int maxHits = 0) const;
 
-    inline TPad* DrawEvent(TString option = "") { return DrawEvent(std::move(option), true); }
-    TPad* DrawEvent(TString option, Bool_t autoBoundaries);
+    inline TPad* DrawEvent(const TString& option = "") { return DrawEvent(option, true); }
+    TPad* DrawEvent(const TString& option, Bool_t autoBoundaries);
 
     // Constructor
     TRestGeant4Event();

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -149,6 +149,7 @@ class TRestGeant4Event : public TRestEvent {
 
     Int_t isVolumeStored(int n) const { return fVolumeStored[n]; }
     inline const TRestGeant4Track& GetTrack(int n) const { return fTrack[n]; }
+    inline TRestGeant4Track* GetTrackPointer(int n) { return &fTrack[n]; }
     TRestGeant4Track* GetTrackByID(int id);
     Int_t GetNumberOfSubEventIDTracks() const { return fMaxSubEventID + 1; }
 

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -52,75 +52,8 @@ class TRestGeant4Event : public TRestEvent {
     Bool_t PerProcessEnergyInitFlag = false;
     std::map<std::string, Double_t> PerProcessEnergyInSensitive;
 
-    void inline InitializePerProcessEnergyInSensitive() {
-        PerProcessEnergyInitFlag = true;
-        PerProcessEnergyInSensitive["photoelectric"] = 0;
-        PerProcessEnergyInSensitive["compton"] = 0;
-        PerProcessEnergyInSensitive["electron_ionization"] = 0;
-        PerProcessEnergyInSensitive["ion_ionization"] = 0;
-        PerProcessEnergyInSensitive["alpha_ionization"] = 0;
-        PerProcessEnergyInSensitive["msc"] = 0;
-        PerProcessEnergyInSensitive["hadronic_ionization"] = 0;
-        PerProcessEnergyInSensitive["proton_ionization"] = 0;
-        PerProcessEnergyInSensitive["hadronic_elastic"] = 0;
-        PerProcessEnergyInSensitive["neutron_elastic"] = 0;
-
-        std::string volume_name;
-        std::string process_name;
-        TRestGeant4Track* track;
-        TRestGeant4Hits* hits;
-        Double_t energy;
-
-        for (Int_t track_id = 0; track_id < GetNumberOfTracks(); track_id++) {
-            track = GetTrack(track_id);
-
-            if (track->GetEnergyInVolume(0) == 0) {
-                continue;
-            }
-
-            hits = track->GetHits();
-
-            for (Int_t hit_id = 0; hit_id < hits->GetNumberOfHits(); hit_id++) {
-                if (hits->GetVolumeId(hit_id) != 0) {
-                    continue;
-                }
-
-                process_name = (std::string)track->GetProcessName(hits->GetHitProcess(hit_id));
-                energy = hits->GetEnergy(hit_id);
-                if (process_name == "phot") {
-                    PerProcessEnergyInSensitive["photoelectric"] += energy;
-                } else if (process_name == "compt") {
-                    PerProcessEnergyInSensitive["compton"] += energy;
-                } else if (process_name == "eIoni" || process_name == "e-Step" || process_name == "e+Step") {
-                    PerProcessEnergyInSensitive["electron_ionization"] += energy;
-                } else if (process_name == "ionIoni") {
-                    PerProcessEnergyInSensitive["ion_ionization"] += energy;
-                    if (track->GetParticleName() == "alpha") {
-                        PerProcessEnergyInSensitive["alpha_ionization"] += energy;
-                    }
-                } else if (process_name == "msc") {
-                    PerProcessEnergyInSensitive["msc"] += energy;
-                } else if (process_name == "hIoni") {
-                    PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
-                    if (track->GetParticleName() == "proton") {
-                        PerProcessEnergyInSensitive["proton_ionization"] += energy;
-                    }
-                } else if (process_name == "hadElastic") {
-                    PerProcessEnergyInSensitive["hadronic_elastic"] += energy;
-                    if (track->GetParticleName() == "neutron") {
-                        PerProcessEnergyInSensitive["neutron_elastic"] += energy;
-                    }
-                } else if (process_name == "Transportation") {
-                    if (track->GetParticleName() == "proton") {
-                        PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
-                        PerProcessEnergyInSensitive["proton_ionization"] += energy;
-                    } else if (track->GetParticleName() == "e-" || track->GetParticleName() == "e+") {
-                        PerProcessEnergyInSensitive["electron_ionization"] += energy;
-                    }
-                }
-            }
-        }
-    }
+    // TODO: review this method
+    void InitializePerProcessEnergyInSensitive();
 
    protected:
 #ifndef __CINT__

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -36,6 +36,7 @@
 
 #include <iostream>
 #include <map>
+#include <utility>
 
 /// An event class to store geant4 generated event information
 class TRestGeant4Event : public TRestEvent {
@@ -130,39 +131,41 @@ class TRestGeant4Event : public TRestEvent {
     void SetBoundaries(Double_t xMin, Double_t xMax, Double_t yMin, Double_t yMax, Double_t zMin,
                        Double_t zMax);
 
-    TString GetPrimaryEventParticleName(int n) {
-        if (fPrimaryParticleName.size() > n) return fPrimaryParticleName[n];
+    inline TString GetPrimaryEventParticleName(int n) const {
+        if (fPrimaryParticleName.size() > n) {
+            return fPrimaryParticleName[n];
+        }
         return "Not defined";
     }
 
-    TVector3 GetPrimaryEventDirection(Int_t n = 0) { return fPrimaryEventDirection[n]; }
-    TVector3 GetPrimaryEventOrigin() { return fPrimaryEventOrigin; }
-    Double_t GetPrimaryEventEnergy(Int_t n = 0) { return fPrimaryEventEnergy[n]; }
+    TVector3 GetPrimaryEventDirection(Int_t n = 0) const { return fPrimaryEventDirection[n]; }
+    TVector3 GetPrimaryEventOrigin() const { return fPrimaryEventOrigin; }
+    Double_t GetPrimaryEventEnergy(Int_t n = 0) const { return fPrimaryEventEnergy[n]; }
 
-    Int_t GetNumberOfHits(Int_t volID = -1);
-    Int_t GetNumberOfTracks() { return fNTracks; }
-    Int_t GetNumberOfPrimaries() { return fPrimaryEventDirection.size(); }
-    Int_t GetNumberOfActiveVolumes() { return fNVolumes; }
+    Int_t GetNumberOfHits(Int_t volID = -1) const;
+    Int_t GetNumberOfTracks() const { return fNTracks; }
+    Int_t GetNumberOfPrimaries() const { return fPrimaryEventDirection.size(); }
+    Int_t GetNumberOfActiveVolumes() const { return fNVolumes; }
 
-    Int_t isVolumeStored(int n) { return fVolumeStored[n]; }
-    TRestGeant4Track* GetTrack(int n) { return &fTrack[n]; }
+    Int_t isVolumeStored(int n) const { return fVolumeStored[n]; }
+    inline const TRestGeant4Track& GetTrack(int n) const { return fTrack[n]; }
     TRestGeant4Track* GetTrackByID(int id);
-    Int_t GetNumberOfSubEventIDTracks() { return fMaxSubEventID + 1; }
+    Int_t GetNumberOfSubEventIDTracks() const { return fMaxSubEventID + 1; }
 
-    Double_t GetTotalDepositedEnergy() { return fTotalDepositedEnergy; }
-    Double_t GetTotalDepositedEnergyFromTracks();
-    Double_t GetEnergyDepositedInVolume(Int_t volID) { return fVolumeDepositedEnergy[volID]; }
-    Double_t GetSensitiveVolumeEnergy() { return fSensitiveVolumeEnergy; }
-    TVector3 GetMeanPositionInVolume(Int_t volID);
-    TVector3 GetFirstPositionInVolume(Int_t volID);
-    TVector3 GetLastPositionInVolume(Int_t volID);
-    TVector3 GetPositionDeviationInVolume(Int_t volID);
+    Double_t GetTotalDepositedEnergy() const { return fTotalDepositedEnergy; }
+    Double_t GetTotalDepositedEnergyFromTracks() const;
+    Double_t GetEnergyDepositedInVolume(Int_t volID) const { return fVolumeDepositedEnergy[volID]; }
+    Double_t GetSensitiveVolumeEnergy() const { return fSensitiveVolumeEnergy; }
+    TVector3 GetMeanPositionInVolume(Int_t volID) const;
+    TVector3 GetFirstPositionInVolume(Int_t volID) const;
+    TVector3 GetLastPositionInVolume(Int_t volID) const;
+    TVector3 GetPositionDeviationInVolume(Int_t volID) const;
 
-    TRestHits GetHits(Int_t volID = -1);
-    TRestHits GetHitsInVolume(Int_t volID) { return GetHits(volID); }
+    TRestHits GetHits(Int_t volID = -1) const;
+    TRestHits GetHitsInVolume(Int_t volID) const { return GetHits(volID); }
 
-    Int_t GetNumberOfTracksForParticle(TString parName);
-    Int_t GetEnergyDepositedByParticle(TString parName);
+    Int_t GetNumberOfTracksForParticle(TString parName) const;
+    Int_t GetEnergyDepositedByParticle(TString parName) const;
 
     Double_t GetEnergyInSensitiveFromProcessPhoto() {
         if (!PerProcessEnergyInitFlag) {
@@ -239,13 +242,15 @@ class TRestGeant4Event : public TRestEvent {
     void SetEnergyDepositedInVolume(Int_t volID, Double_t eDep) { fVolumeDepositedEnergy[volID] = eDep; }
     void SetSensitiveVolumeEnergy(Double_t en) { fSensitiveVolumeEnergy = en; }
 
-    Int_t GetLowestTrackID() {
+    inline Int_t GetLowestTrackID() const {
         Int_t lowestID = 0;
-        if (fNTracks > 0) lowestID = GetTrack(0)->GetTrackID();
+        if (fNTracks > 0) {
+            lowestID = GetTrack(0).GetTrackID();
+        }
 
         for (int i = 0; i < fNTracks; i++) {
-            TRestGeant4Track* tr = GetTrack(i);
-            if (tr->GetTrackID() < lowestID) lowestID = tr->GetTrackID();
+            auto tr = GetTrack(i);
+            if (tr.GetTrackID() < lowestID) lowestID = tr.GetTrackID();
         }
 
         return lowestID;
@@ -254,182 +259,182 @@ class TRestGeant4Event : public TRestEvent {
     void SetTrackSubEventID(Int_t n, Int_t id);
     void AddTrack(TRestGeant4Track trk);
 
-    Bool_t isRadiactiveDecay() {
+    inline Bool_t isRadiactiveDecay() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isRadiactiveDecay()) return true;
+            if (GetTrack(n).isRadiactiveDecay()) return true;
         return false;
     }
 
-    Bool_t isPhotoElectric() {
+    inline Bool_t isPhotoElectric() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isPhotoElectric()) return true;
+            if (GetTrack(n).isPhotoElectric()) return true;
         return false;
     }
-    Bool_t isCompton() {
+    inline Bool_t isCompton() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isCompton()) return true;
+            if (GetTrack(n).isCompton()) return true;
         return false;
     }
-    Bool_t isBremstralung() {
+    inline Bool_t isBremstralung() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isBremstralung()) return true;
-        return false;
-    }
-
-    Bool_t ishadElastic() {
-        for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->ishadElastic()) return true;
-        return false;
-    }
-    Bool_t isneutronInelastic() {
-        for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isneutronInelastic()) return true;
+            if (GetTrack(n).isBremstralung()) return true;
         return false;
     }
 
-    Bool_t isnCapture() {
+    inline Bool_t ishadElastic() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isnCapture()) return true;
+            if (GetTrack(n).ishadElastic()) return true;
+        return false;
+    }
+    inline Bool_t isneutronInelastic() const {
+        for (int n = 0; n < GetNumberOfTracks(); n++)
+            if (GetTrack(n).isneutronInelastic()) return true;
         return false;
     }
 
-    Bool_t ishIoni() {
+    inline Bool_t isnCapture() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->ishIoni()) return true;
+            if (GetTrack(n).isnCapture()) return true;
         return false;
     }
 
-    Bool_t isphotonNuclear() {
+    inline Bool_t ishIoni() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isphotonNuclear()) return true;
+            if (GetTrack(n).ishIoni()) return true;
         return false;
     }
 
-    Bool_t isAlpha() {
+    inline Bool_t isphotonNuclear() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->GetParticleName() == "alpha") return true;
+            if (GetTrack(n).isphotonNuclear()) return true;
         return false;
     }
 
-    Bool_t isNeutron() {
+    inline Bool_t isAlpha() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->GetParticleName() == "neutron") return true;
+            if (GetTrack(n).GetParticleName() == "alpha") return true;
         return false;
     }
 
-    Bool_t isArgon() {
+    inline Bool_t isNeutron() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if ((GetTrack(n)->GetParticleName()).Contains("Ar")) return true;
+            if (GetTrack(n).GetParticleName() == "neutron") return true;
         return false;
     }
 
-    Bool_t isXenon() {
+    inline Bool_t isArgon() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if ((GetTrack(n)->GetParticleName()).Contains("Xe")) return true;
+            if ((GetTrack(n).GetParticleName()).Contains("Ar")) return true;
         return false;
     }
 
-    Bool_t isNeon() {
+    inline Bool_t isXenon() const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if ((GetTrack(n)->GetParticleName()).Contains("Ne")) return true;
+            if ((GetTrack(n).GetParticleName()).Contains("Xe")) return true;
+        return false;
+    }
+
+    inline Bool_t isNeon() const {
+        for (int n = 0; n < GetNumberOfTracks(); n++)
+            if ((GetTrack(n).GetParticleName()).Contains("Ne")) return true;
         return false;
     }
     /// Processes and particles in a given volume
 
-    Bool_t isRadiactiveDecayInVolume(Int_t volID) {
+    inline Bool_t isRadiactiveDecayInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isRadiactiveDecayInVolume(volID)) return true;
+            if (GetTrack(n).isRadiactiveDecayInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isPhotoElectricInVolume(Int_t volID) {
+    inline Bool_t isPhotoElectricInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isPhotoElectricInVolume(volID)) return true;
+            if (GetTrack(n).isPhotoElectricInVolume(volID)) return true;
         return false;
     }
-    Bool_t isPhotonNuclearInVolume(Int_t volID) {
+    inline Bool_t isPhotonNuclearInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isPhotonNuclearInVolume(volID)) return true;
+            if (GetTrack(n).isPhotonNuclearInVolume(volID)) return true;
         return false;
     }
-    Bool_t isComptonInVolume(Int_t volID) {
+    inline Bool_t isComptonInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isComptonInVolume(volID)) return true;
+            if (GetTrack(n).isComptonInVolume(volID)) return true;
         return false;
     }
-    Bool_t isBremstralungInVolume(Int_t volID) {
+    inline Bool_t isBremstralungInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isBremstralungInVolume(volID)) return true;
-        return false;
-    }
-
-    Bool_t isHadElasticInVolume(Int_t volID) {
-        for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isHadElasticInVolume(volID)) return true;
-        return false;
-    }
-    Bool_t isNeutronInelasticInVolume(Int_t volID) {
-        for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isNeutronInelasticInVolume(volID)) return true;
+            if (GetTrack(n).isBremstralungInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isNCaptureInVolume(Int_t volID) {
+    inline Bool_t isHadElasticInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isNCaptureInVolume(volID)) return true;
+            if (GetTrack(n).isHadElasticInVolume(volID)) return true;
+        return false;
+    }
+    inline Bool_t isNeutronInelasticInVolume(Int_t volID) const {
+        for (int n = 0; n < GetNumberOfTracks(); n++)
+            if (GetTrack(n).isNeutronInelasticInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t ishIoniInVolume(Int_t volID) {
+    inline Bool_t isNCaptureInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isHIoniInVolume(volID)) return true;
+            if (GetTrack(n).isNCaptureInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isAlphaInVolume(Int_t volID) {
+    inline Bool_t ishIoniInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isAlphaInVolume(volID)) return true;
+            if (GetTrack(n).isHIoniInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isNeutronInVolume(Int_t volID) {
+    inline Bool_t isAlphaInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isNeutronInVolume(volID)) return true;
+            if (GetTrack(n).isAlphaInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isArgonInVolume(Int_t volID) {
+    inline Bool_t isNeutronInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isArgonInVolume(volID)) return true;
+            if (GetTrack(n).isNeutronInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isXenonInVolume(Int_t volID) {
+    inline Bool_t isArgonInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isXenonInVolume(volID)) return true;
+            if (GetTrack(n).isArgonInVolume(volID)) return true;
         return false;
     }
 
-    Bool_t isNeonInVolume(Int_t volID) {
+    inline Bool_t isXenonInVolume(Int_t volID) const {
         for (int n = 0; n < GetNumberOfTracks(); n++)
-            if (GetTrack(n)->isNeonInVolume(volID)) return true;
+            if (GetTrack(n).isXenonInVolume(volID)) return true;
+        return false;
+    }
+
+    inline Bool_t isNeonInVolume(Int_t volID) const {
+        for (int n = 0; n < GetNumberOfTracks(); n++)
+            if (GetTrack(n).isNeonInVolume(volID)) return true;
         return false;
     }
 
     void Initialize();
 
     /// maxTracks : number of tracks to print, 0 = all
-    void PrintActiveVolumes();
-    void PrintEvent(int maxTracks = 0, int maxHits = 0);
+    void PrintActiveVolumes() const;
+    void PrintEvent(int maxTracks = 0, int maxHits = 0) const;
 
-    TPad* DrawEvent(TString option = "") { return DrawEvent(option, true); }
+    TPad* DrawEvent(TString option = "") { return DrawEvent(std::move(option), true); }
     TPad* DrawEvent(TString option, Bool_t autoBoundaries);
 
-    // Construtor
+    // Constructor
     TRestGeant4Event();
     // Destructor
     virtual ~TRestGeant4Event();
 
-    ClassDef(TRestGeant4Event, 5);  // REST event superclass
+    ClassDef(TRestGeant4Event, 6);  // REST event superclass
 };
 #endif

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -143,105 +143,107 @@ class TRestGeant4Event : public TRestEvent {
     Double_t GetPrimaryEventEnergy(Int_t n = 0) const { return fPrimaryEventEnergy[n]; }
 
     Int_t GetNumberOfHits(Int_t volID = -1) const;
-    Int_t GetNumberOfTracks() const { return fNTracks; }
-    Int_t GetNumberOfPrimaries() const { return fPrimaryEventDirection.size(); }
-    Int_t GetNumberOfActiveVolumes() const { return fNVolumes; }
+    inline Int_t GetNumberOfTracks() const { return fNTracks; }
+    inline Int_t GetNumberOfPrimaries() const { return fPrimaryEventDirection.size(); }
+    inline Int_t GetNumberOfActiveVolumes() const { return fNVolumes; }
 
-    Int_t isVolumeStored(int n) const { return fVolumeStored[n]; }
+    inline Int_t isVolumeStored(int n) const { return fVolumeStored[n]; }
     inline const TRestGeant4Track& GetTrack(int n) const { return fTrack[n]; }
     inline TRestGeant4Track* GetTrackPointer(int n) { return &fTrack[n]; }
     TRestGeant4Track* GetTrackByID(int id);
-    Int_t GetNumberOfSubEventIDTracks() const { return fMaxSubEventID + 1; }
+    inline Int_t GetNumberOfSubEventIDTracks() const { return fMaxSubEventID + 1; }
 
-    Double_t GetTotalDepositedEnergy() const { return fTotalDepositedEnergy; }
+    inline Double_t GetTotalDepositedEnergy() const { return fTotalDepositedEnergy; }
     Double_t GetTotalDepositedEnergyFromTracks() const;
-    Double_t GetEnergyDepositedInVolume(Int_t volID) const { return fVolumeDepositedEnergy[volID]; }
-    Double_t GetSensitiveVolumeEnergy() const { return fSensitiveVolumeEnergy; }
+    inline Double_t GetEnergyDepositedInVolume(Int_t volID) const { return fVolumeDepositedEnergy[volID]; }
+    inline Double_t GetSensitiveVolumeEnergy() const { return fSensitiveVolumeEnergy; }
     TVector3 GetMeanPositionInVolume(Int_t volID) const;
     TVector3 GetFirstPositionInVolume(Int_t volID) const;
     TVector3 GetLastPositionInVolume(Int_t volID) const;
     TVector3 GetPositionDeviationInVolume(Int_t volID) const;
 
     TRestHits GetHits(Int_t volID = -1) const;
-    TRestHits GetHitsInVolume(Int_t volID) const { return GetHits(volID); }
+    inline TRestHits GetHitsInVolume(Int_t volID) const { return GetHits(volID); }
 
     Int_t GetNumberOfTracksForParticle(TString parName) const;
     Int_t GetEnergyDepositedByParticle(TString parName) const;
 
-    Double_t GetEnergyInSensitiveFromProcessPhoto() {
+    inline Double_t GetEnergyInSensitiveFromProcessPhoto() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["photoelectric"];
     }
-    Double_t GetEnergyInSensitiveFromProcessCompton() {
+    inline Double_t GetEnergyInSensitiveFromProcessCompton() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["compton"];
     }
-    Double_t GetEnergyInSensitiveFromProcessEIoni() {
+    inline Double_t GetEnergyInSensitiveFromProcessEIoni() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["electron_ionization"];
     }
-    Double_t GetEnergyInSensitiveFromProcessIonIoni() {
+    inline Double_t GetEnergyInSensitiveFromProcessIonIoni() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["ion_ionization"];
     }
-    Double_t GetEnergyInSensitiveFromProcessAlphaIoni() {
+    inline Double_t GetEnergyInSensitiveFromProcessAlphaIoni() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["alpha_ionization"];
     }
-    Double_t GetEnergyInSensitiveFromProcessMsc() {
+    inline Double_t GetEnergyInSensitiveFromProcessMsc() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["msc"];
     }
-    Double_t GetEnergyInSensitiveFromProcessHadronIoni() {
+    inline Double_t GetEnergyInSensitiveFromProcessHadronIoni() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["hadronic_ionization"];
     }
-    Double_t GetEnergyInSensitiveFromProcessProtonIoni() {
+    inline Double_t GetEnergyInSensitiveFromProcessProtonIoni() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["proton_ionization"];
     }
-    Double_t GetEnergyInSensitiveFromProcessHadronElastic() {
+    inline Double_t GetEnergyInSensitiveFromProcessHadronElastic() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["hadronic_elastic"];
     }
-    Double_t GetEnergyInSensitiveFromProcessNeutronElastic() {
+    inline Double_t GetEnergyInSensitiveFromProcessNeutronElastic() {
         if (!PerProcessEnergyInitFlag) {
             InitializePerProcessEnergyInSensitive();
         }
         return PerProcessEnergyInSensitive["neutron_elastic"];
     }
 
-    void SetPrimaryEventOrigin(TVector3 pos) { fPrimaryEventOrigin = pos; }
-    void SetPrimaryEventDirection(TVector3 dir) { fPrimaryEventDirection.push_back(dir); }
-    void SetPrimaryEventParticleName(TString pName) { fPrimaryParticleName.push_back(pName); }
-    void SetPrimaryEventEnergy(Double_t en) { fPrimaryEventEnergy.push_back(en); }
-    void ActivateVolumeForStorage(Int_t n) { fVolumeStored[n] = 1; }
-    void DisableVolumeForStorage(Int_t n) { fVolumeStored[n] = 0; }
+    inline void SetPrimaryEventOrigin(TVector3 pos) { fPrimaryEventOrigin = pos; }
+    inline void SetPrimaryEventDirection(TVector3 dir) { fPrimaryEventDirection.push_back(dir); }
+    inline void SetPrimaryEventParticleName(TString pName) { fPrimaryParticleName.push_back(pName); }
+    inline void SetPrimaryEventEnergy(Double_t en) { fPrimaryEventEnergy.push_back(en); }
+    inline void ActivateVolumeForStorage(Int_t n) { fVolumeStored[n] = 1; }
+    inline void DisableVolumeForStorage(Int_t n) { fVolumeStored[n] = 0; }
 
     void AddActiveVolume(const std::string& volumeName);
     void ClearVolumes();
-    void AddEnergyToSensitiveVolume(Double_t en) { fSensitiveVolumeEnergy += en; }
+    inline void AddEnergyToSensitiveVolume(Double_t en) { fSensitiveVolumeEnergy += en; }
 
-    void SetEnergyDepositedInVolume(Int_t volID, Double_t eDep) { fVolumeDepositedEnergy[volID] = eDep; }
-    void SetSensitiveVolumeEnergy(Double_t en) { fSensitiveVolumeEnergy = en; }
+    inline void SetEnergyDepositedInVolume(Int_t volID, Double_t eDep) {
+        fVolumeDepositedEnergy[volID] = eDep;
+    }
+    inline void SetSensitiveVolumeEnergy(Double_t en) { fSensitiveVolumeEnergy = en; }
 
     inline Int_t GetLowestTrackID() const {
         Int_t lowestID = 0;
@@ -428,7 +430,7 @@ class TRestGeant4Event : public TRestEvent {
     void PrintActiveVolumes() const;
     void PrintEvent(int maxTracks = 0, int maxHits = 0) const;
 
-    TPad* DrawEvent(TString option = "") { return DrawEvent(std::move(option), true); }
+    inline TPad* DrawEvent(TString option = "") { return DrawEvent(std::move(option), true); }
     TPad* DrawEvent(TString option, Bool_t autoBoundaries);
 
     // Constructor

--- a/inc/TRestGeant4Hits.h
+++ b/inc/TRestGeant4Hits.h
@@ -37,26 +37,26 @@ class TRestGeant4Hits : public TRestHits {
     TArrayF fMomentumDirectionY;
     TArrayF fMomentumDirectionZ;
 
-    TVector3 GetMomentumDirection(int n) {
-        return TVector3(fMomentumDirectionX[n], fMomentumDirectionY[n], fMomentumDirectionZ[n]);
+    TVector3 GetMomentumDirection(int n) const {
+        return {fMomentumDirectionX[n], fMomentumDirectionY[n], fMomentumDirectionZ[n]};
     }
 
-    Int_t GetProcess(int n) { return fProcessID[n]; }
+    Int_t GetProcess(int n) const { return fProcessID[n]; }
 
     void AddG4Hit(TVector3 pos, Double_t en, Double_t hit_global_time, Int_t process, Int_t volume,
                   Double_t eKin, TVector3 momentumDirection);
     void RemoveG4Hits();
 
-    Int_t GetHitProcess(int n) { return fProcessID[n]; }
-    Int_t GetHitVolume(int n) { return fVolumeID[n]; }
-    Int_t GetVolumeId(int n) { return fVolumeID[n]; }
-    Double_t GetKineticEnergy(int n) { return fKineticEnergy[n]; }
+    Int_t GetHitProcess(int n) const { return fProcessID[n]; }
+    Int_t GetHitVolume(int n) const { return fVolumeID[n]; }
+    Int_t GetVolumeId(int n) const { return fVolumeID[n]; }
+    Double_t GetKineticEnergy(int n) const { return fKineticEnergy[n]; }
 
-    Double_t GetEnergyInVolume(Int_t volID);
+    Double_t GetEnergyInVolume(Int_t volID) const;
 
-    TVector3 GetMeanPositionInVolume(Int_t volID);
-    TVector3 GetFirstPositionInVolume(Int_t volID);
-    TVector3 GetLastPositionInVolume(Int_t volID);
+    TVector3 GetMeanPositionInVolume(Int_t volID) const;
+    TVector3 GetFirstPositionInVolume(Int_t volID) const;
+    TVector3 GetLastPositionInVolume(Int_t volID) const;
 
     // Constructor
     TRestGeant4Hits();

--- a/inc/TRestGeant4Track.h
+++ b/inc/TRestGeant4Track.h
@@ -54,28 +54,28 @@ class TRestGeant4Track : public TObject {
         fSubEventId = 0.;
     }
 
-    TRestGeant4Hits* GetHits() { return &fHits; }
+    inline const TRestGeant4Hits& GetHits() const { return fHits; }
 
-    Double_t GetEnergy() { return GetHits()->GetEnergy(); }
+    inline Double_t GetEnergy() const { return fHits.GetEnergy(); }
 
-    Int_t GetNumberOfHits(Int_t volID = -1);
-    Int_t GetTrackID() { return fTrack_ID; }
-    Int_t GetParentID() { return fParent_ID; }
+    Int_t GetNumberOfHits(Int_t volID = -1) const;
+    inline Int_t GetTrackID() const { return fTrack_ID; }
+    inline Int_t GetParentID() const { return fParent_ID; }
 
-    TString GetParticleName() { return fParticleName; }
-    EColor GetParticleColor();
+    inline TString GetParticleName() const { return fParticleName; }
+    EColor GetParticleColor() const;
 
-    Double_t GetGlobalTime() { return fGlobalTimestamp; }
-    Double_t GetTrackTimeLength() { return fTrackTimestamp; }
-    Double_t GetKineticEnergy() { return fKineticEnergy; }
-    Double_t GetTotalDepositedEnergy() { return fHits.GetTotalDepositedEnergy(); }
-    TVector3 GetTrackOrigin() { return fTrackOrigin; }
-    Int_t GetSubEventID() { return fSubEventId; }
+    inline Double_t GetGlobalTime() const { return fGlobalTimestamp; }
+    inline Double_t GetTrackTimeLength() const { return fTrackTimestamp; }
+    inline Double_t GetKineticEnergy() const { return fKineticEnergy; }
+    inline Double_t GetTotalDepositedEnergy() const { return fHits.GetTotalDepositedEnergy(); }
+    inline TVector3 GetTrackOrigin() const { return fTrackOrigin; }
+    inline Int_t GetSubEventID() const { return fSubEventId; }
 
-    Double_t GetEnergyInVolume(Int_t volID) { return GetHits()->GetEnergyInVolume(volID); }
-    TVector3 GetMeanPositionInVolume(Int_t volID) { return GetHits()->GetMeanPositionInVolume(volID); }
-    TVector3 GetFirstPositionInVolume(Int_t volID) { return GetHits()->GetFirstPositionInVolume(volID); }
-    TVector3 GetLastPositionInVolume(Int_t volID) { return GetHits()->GetLastPositionInVolume(volID); }
+    Double_t GetEnergyInVolume(Int_t volID) const { return fHits.GetEnergyInVolume(volID); }
+    TVector3 GetMeanPositionInVolume(Int_t volID) const { return fHits.GetMeanPositionInVolume(volID); }
+    TVector3 GetFirstPositionInVolume(Int_t volID) const { return fHits.GetFirstPositionInVolume(volID); }
+    TVector3 GetLastPositionInVolume(Int_t volID) const { return fHits.GetLastPositionInVolume(volID); }
 
     void SetSubEventID(Int_t id) { fSubEventId = id; }
 
@@ -105,151 +105,151 @@ class TRestGeant4Track : public TObject {
 
     // TODO move this to a namespace header??
     Int_t GetProcessID(TString pcsName);
-    TString GetProcessName(Int_t id);
+    TString GetProcessName(Int_t id) const;
 
-    Bool_t isRadiactiveDecay() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 11) return true;
+    Bool_t isRadiactiveDecay() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 11) return true;
         return false;
     }
-    Bool_t isPhotoElectric() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 3) return true;
+    Bool_t isPhotoElectric() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 3) return true;
         return false;
     }
-    Bool_t isCompton() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 7) return true;
+    Bool_t isCompton() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 7) return true;
         return false;
     }
-    Bool_t isBremstralung() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 5) return true;
-        return false;
-    }
-
-    Bool_t ishadElastic() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 36) return true;
-        return false;
-    }
-    Bool_t isneutronInelastic() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 37) return true;
-        return false;
-    }
-    Bool_t isnCapture() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 38) return true;
+    Bool_t isBremstralung() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 5) return true;
         return false;
     }
 
-    Bool_t ishIoni() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 33) return true;
+    Bool_t ishadElastic() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 36) return true;
         return false;
     }
-    Bool_t isphotonNuclear() {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if (GetHits()->GetHitProcess(n) == 42) return true;
+    Bool_t isneutronInelastic() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 37) return true;
+        return false;
+    }
+    Bool_t isnCapture() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 38) return true;
+        return false;
+    }
+
+    Bool_t ishIoni() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 33) return true;
+        return false;
+    }
+    Bool_t isphotonNuclear() const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if (fHits.GetHitProcess(n) == 42) return true;
         return false;
     }
     // Processes in active volume
-    Bool_t isRadiactiveDecayInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 11) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isRadiactiveDecayInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 11) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isPhotoElectricInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 3) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isPhotoElectricInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 3) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isPhotonNuclearInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 42) && (GetHits()->GetHitVolume(n)) == volID) return true;
-        return false;
-    }
-
-    Bool_t isComptonInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 7) && (GetHits()->GetHitVolume(n)) == volID) return true;
-        return false;
-    }
-    Bool_t isBremstralungInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 5) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isPhotonNuclearInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 42) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isHadElasticInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 36) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isComptonInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 7) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isNeutronInelasticInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 37) && (GetHits()->GetHitVolume(n)) == volID) return true;
-        return false;
-    }
-
-    Bool_t isNCaptureInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 38) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isBremstralungInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 5) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isHIoniInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitProcess(n) == 33) && (GetHits()->GetHitVolume(n)) == volID) return true;
+    Bool_t isHadElasticInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 36) && (fHits.GetHitVolume(n)) == volID) return true;
+        return false;
+    }
+    Bool_t isNeutronInelasticInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 37) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isAlphaInVolume(Int_t volID) {
+    Bool_t isNCaptureInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 38) && (fHits.GetHitVolume(n)) == volID) return true;
+        return false;
+    }
+
+    Bool_t isHIoniInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitProcess(n) == 33) && (fHits.GetHitVolume(n)) == volID) return true;
+        return false;
+    }
+
+    Bool_t isAlphaInVolume(Int_t volID) const {
         if (GetParticleName() == "alpha") {
-            for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-                if ((GetHits()->GetHitVolume(n)) == volID) return true;
+            for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+                if ((fHits.GetHitVolume(n)) == volID) return true;
         }
         return false;
     }
 
-    Bool_t isNeutronInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitVolume(n) == volID) && (GetParticleName() == "neutron")) return true;
+    Bool_t isNeutronInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitVolume(n) == volID) && (GetParticleName() == "neutron")) return true;
         return false;
     }
 
-    Bool_t isArgonInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitVolume(n) == volID) && (GetParticleName().Contains("Ar"))) return true;
+    Bool_t isArgonInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Ar"))) return true;
         return false;
     }
 
-    Bool_t isNeonInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitVolume(n) == volID) && (GetParticleName().Contains("Ne"))) return true;
+    Bool_t isNeonInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Ne"))) return true;
         return false;
     }
 
-    Bool_t isXenonInVolume(Int_t volID) {
-        for (int n = 0; n < GetHits()->GetNumberOfHits(); n++)
-            if ((GetHits()->GetHitVolume(n) == volID) && (GetParticleName().Contains("Xe"))) return true;
+    Bool_t isXenonInVolume(Int_t volID) const {
+        for (int n = 0; n < fHits.GetNumberOfHits(); n++)
+            if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Xe"))) return true;
         return false;
     }
     /////////////////////////////////
 
     /// Prints the track information. N number of hits to print, 0 = all
-    void PrintTrack(int maxHits = 0);
+    void PrintTrack(int maxHits = 0) const;
 
     //    Int_t GetElement( Int_t n ) { return X.At(n); }
 
     //    Int_t GetParticleID();
-    // Construtor
+    // Constructor
     TRestGeant4Track();
     // Destructor
     virtual ~TRestGeant4Track();
 
-    ClassDef(TRestGeant4Track, 2);  // REST event superclass
+    ClassDef(TRestGeant4Track, 3);  // REST event superclass
 };
 
 #endif

--- a/inc/TRestGeant4Track.h
+++ b/inc/TRestGeant4Track.h
@@ -36,7 +36,7 @@ class TRestGeant4Track : public TObject {
 
     Int_t fSubEventId;
 
-    // We must change this to save space! (Might be not needed afterall)
+    // We must change this to save space! (Might be not needed after all)
     // Int_t fParticle_ID;
     TString fParticleName;
 
@@ -49,7 +49,7 @@ class TRestGeant4Track : public TObject {
     TVector3 fTrackOrigin;
 
    public:
-    void Initialize() {
+    inline void Initialize() {
         RemoveHits();
         fSubEventId = 0.;
     }
@@ -72,140 +72,145 @@ class TRestGeant4Track : public TObject {
     inline TVector3 GetTrackOrigin() const { return fTrackOrigin; }
     inline Int_t GetSubEventID() const { return fSubEventId; }
 
-    Double_t GetEnergyInVolume(Int_t volID) const { return fHits.GetEnergyInVolume(volID); }
-    TVector3 GetMeanPositionInVolume(Int_t volID) const { return fHits.GetMeanPositionInVolume(volID); }
-    TVector3 GetFirstPositionInVolume(Int_t volID) const { return fHits.GetFirstPositionInVolume(volID); }
-    TVector3 GetLastPositionInVolume(Int_t volID) const { return fHits.GetLastPositionInVolume(volID); }
+    inline Double_t GetEnergyInVolume(Int_t volID) const { return fHits.GetEnergyInVolume(volID); }
+    inline TVector3 GetMeanPositionInVolume(Int_t volID) const {
+        return fHits.GetMeanPositionInVolume(volID);
+    }
+    inline TVector3 GetFirstPositionInVolume(Int_t volID) const {
+        return fHits.GetFirstPositionInVolume(volID);
+    }
+    inline TVector3 GetLastPositionInVolume(Int_t volID) const {
+        return fHits.GetLastPositionInVolume(volID);
+    }
 
     void SetSubEventID(Int_t id) { fSubEventId = id; }
-
     void SetTrackID(Int_t id) { fTrack_ID = id; }
     void SetParentID(Int_t id) { fParent_ID = id; }
     //       void SetParticleID( Int_t id ) { fParticle_ID = id; }
-    void SetParticleName(TString ptcleName) { fParticleName = ptcleName; }
+    void SetParticleName(const TString& particleName) { fParticleName = particleName; }
     void SetGlobalTrackTime(Double_t time) { fGlobalTimestamp = time; }
     void SetTrackTimeLength(Double_t time) { fTrackTimestamp = time; }
     void SetKineticEnergy(Double_t en) { fKineticEnergy = en; }
-    void SetTrackOrigin(TVector3 pos) { fTrackOrigin = pos; }
+    void SetTrackOrigin(const TVector3& pos) { fTrackOrigin = pos; }
     void SetTrackOrigin(Double_t x, Double_t y, Double_t z) { fTrackOrigin.SetXYZ(x, y, z); }
 
-    void AddG4Hit(TVector3 pos, Double_t en, Double_t hit_global_time, Int_t pcs, Int_t vol, Double_t eKin,
-                  TVector3 momentumDirection) {
+    void AddG4Hit(const TVector3& pos, Double_t en, Double_t hit_global_time, Int_t pcs, Int_t vol,
+                  Double_t eKin, const TVector3& momentumDirection) {
         fHits.AddG4Hit(pos, en, hit_global_time, pcs, vol, eKin, momentumDirection);
     }
 
-    Double_t GetTrackLength();
+    Double_t GetTrackLength() const;
 
-    Double_t GetDistance(TVector3 v1, TVector3 v2) {
+    inline static Double_t GetDistance(const TVector3& v1, const TVector3& v2) {
         return TMath::Sqrt((v1.X() - v2.X()) * (v1.X() - v2.X()) + (v1.Y() - v2.Y()) * (v1.Y() - v2.Y()) +
                            (v1.Z() - v2.Z()) * (v1.Z() - v2.Z()));
     }
 
-    void RemoveHits() { fHits.RemoveHits(); }
+    inline void RemoveHits() { fHits.RemoveHits(); }
 
     // TODO move this to a namespace header??
-    Int_t GetProcessID(TString pcsName);
+    Int_t GetProcessID(const TString& pcsName);
     TString GetProcessName(Int_t id) const;
 
-    Bool_t isRadiactiveDecay() const {
+    inline Bool_t isRadiactiveDecay() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 11) return true;
         return false;
     }
-    Bool_t isPhotoElectric() const {
+    inline Bool_t isPhotoElectric() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 3) return true;
         return false;
     }
-    Bool_t isCompton() const {
+    inline Bool_t isCompton() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 7) return true;
         return false;
     }
-    Bool_t isBremstralung() const {
+    inline Bool_t isBremstralung() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 5) return true;
         return false;
     }
 
-    Bool_t ishadElastic() const {
+    inline Bool_t ishadElastic() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 36) return true;
         return false;
     }
-    Bool_t isneutronInelastic() const {
+    inline Bool_t isneutronInelastic() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 37) return true;
         return false;
     }
-    Bool_t isnCapture() const {
+    inline Bool_t isnCapture() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 38) return true;
         return false;
     }
 
-    Bool_t ishIoni() const {
+    inline Bool_t ishIoni() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 33) return true;
         return false;
     }
-    Bool_t isphotonNuclear() const {
+    inline Bool_t isphotonNuclear() const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if (fHits.GetHitProcess(n) == 42) return true;
         return false;
     }
     // Processes in active volume
-    Bool_t isRadiactiveDecayInVolume(Int_t volID) const {
+    inline Bool_t isRadiactiveDecayInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 11) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isPhotoElectricInVolume(Int_t volID) const {
+    inline Bool_t isPhotoElectricInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 3) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isPhotonNuclearInVolume(Int_t volID) const {
+    inline Bool_t isPhotonNuclearInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 42) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isComptonInVolume(Int_t volID) const {
+    inline Bool_t isComptonInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 7) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isBremstralungInVolume(Int_t volID) const {
+    inline Bool_t isBremstralungInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 5) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isHadElasticInVolume(Int_t volID) const {
+    inline Bool_t isHadElasticInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 36) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
-    Bool_t isNeutronInelasticInVolume(Int_t volID) const {
+    inline Bool_t isNeutronInelasticInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 37) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isNCaptureInVolume(Int_t volID) const {
+    inline Bool_t isNCaptureInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 38) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isHIoniInVolume(Int_t volID) const {
+    inline Bool_t isHIoniInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitProcess(n) == 33) && (fHits.GetHitVolume(n)) == volID) return true;
         return false;
     }
 
-    Bool_t isAlphaInVolume(Int_t volID) const {
+    inline Bool_t isAlphaInVolume(Int_t volID) const {
         if (GetParticleName() == "alpha") {
             for (int n = 0; n < fHits.GetNumberOfHits(); n++)
                 if ((fHits.GetHitVolume(n)) == volID) return true;
@@ -213,25 +218,25 @@ class TRestGeant4Track : public TObject {
         return false;
     }
 
-    Bool_t isNeutronInVolume(Int_t volID) const {
+    inline Bool_t isNeutronInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitVolume(n) == volID) && (GetParticleName() == "neutron")) return true;
         return false;
     }
 
-    Bool_t isArgonInVolume(Int_t volID) const {
+    inline Bool_t isArgonInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Ar"))) return true;
         return false;
     }
 
-    Bool_t isNeonInVolume(Int_t volID) const {
+    inline Bool_t isNeonInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Ne"))) return true;
         return false;
     }
 
-    Bool_t isXenonInVolume(Int_t volID) const {
+    inline Bool_t isXenonInVolume(Int_t volID) const {
         for (int n = 0; n < fHits.GetNumberOfHits(); n++)
             if ((fHits.GetHitVolume(n) == volID) && (GetParticleName().Contains("Xe"))) return true;
         return false;

--- a/src/TRestGeant4BlobAnalysisProcess.cxx
+++ b/src/TRestGeant4BlobAnalysisProcess.cxx
@@ -77,9 +77,9 @@ TRestEvent* TRestGeant4BlobAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
     Double_t xBlob2 = 0, yBlob2 = 0, zBlob2 = 0;
 
     for (int tck = 0; tck < fG4Event->GetNumberOfTracks(); tck++) {
-        TRestGeant4Track* track = fG4Event->GetTrack(tck);
-        if (track->GetParentID() == 0) {
-            if (track->GetParticleName() != "e-") {
+        const auto& track = fG4Event->GetTrack(tck);
+        if (track.GetParentID() == 0) {
+            if (track.GetParticleName() != "e-") {
                 cout << "TRestGeant4BlobAnalysis Warning. Primary particle is not an "
                         "electron!!"
                      << endl;
@@ -87,7 +87,7 @@ TRestEvent* TRestGeant4BlobAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
                 continue;
             }
 
-            if (track->GetNumberOfHits() == 0) {
+            if (track.GetNumberOfHits() == 0) {
                 cout << "REST. FindG4Blobs WARNING. A primary electron with no hits "
                         "was found!!"
                      << endl;
@@ -102,16 +102,16 @@ TRestEvent* TRestGeant4BlobAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
                 continue;
             }
 
-            Int_t nHits = track->GetNumberOfHits();
+            Int_t nHits = track.GetNumberOfHits();
 
             if (nBlobs == 0) {
-                xBlob1 = track->GetHits()->GetX(nHits - 1);
-                yBlob1 = track->GetHits()->GetY(nHits - 1);
-                zBlob1 = track->GetHits()->GetZ(nHits - 1);
+                xBlob1 = track.GetHits().GetX(nHits - 1);
+                yBlob1 = track.GetHits().GetY(nHits - 1);
+                zBlob1 = track.GetHits().GetZ(nHits - 1);
             } else {
-                xBlob2 = track->GetHits()->GetX(nHits - 1);
-                yBlob2 = track->GetHits()->GetY(nHits - 1);
-                zBlob2 = track->GetHits()->GetZ(nHits - 1);
+                xBlob2 = track.GetHits().GetX(nHits - 1);
+                yBlob2 = track.GetHits().GetY(nHits - 1);
+                zBlob2 = track.GetHits().GetZ(nHits - 1);
             }
 
             nBlobs++;

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -120,31 +120,32 @@ void TRestGeant4Event::AddTrack(TRestGeant4Track trk) {
         fVolumeDepositedEnergy[n] += trk.GetEnergyInVolume(n);
 }
 
-Double_t TRestGeant4Event::GetTotalDepositedEnergyFromTracks() {
+Double_t TRestGeant4Event::GetTotalDepositedEnergyFromTracks() const {
     Double_t eDep = 0;
 
-    for (int tk = 0; tk < GetNumberOfTracks(); tk++) eDep += GetTrack(tk)->GetTotalDepositedEnergy();
+    for (int tk = 0; tk < GetNumberOfTracks(); tk++) {
+        eDep += GetTrack(tk).GetTotalDepositedEnergy();
+    }
 
     return eDep;
 }
 
-TVector3 TRestGeant4Event::GetMeanPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Event::GetMeanPositionInVolume(Int_t volID) const {
     TVector3 pos;
     Double_t eDep = 0;
 
     for (int t = 0; t < GetNumberOfTracks(); t++) {
-        TRestGeant4Track* tck = GetTrack(t);
-        if (tck->GetEnergyInVolume(volID) > 0) {
-            pos += tck->GetMeanPositionInVolume(volID) * tck->GetEnergyInVolume(volID);
+        const auto tck = GetTrack(t);
+        if (tck.GetEnergyInVolume(volID) > 0) {
+            pos += tck.GetMeanPositionInVolume(volID) * tck.GetEnergyInVolume(volID);
 
-            eDep += tck->GetEnergyInVolume(volID);
+            eDep += tck.GetEnergyInVolume(volID);
         }
     }
 
     if (eDep == 0) {
-        TVector3 pos;
         Double_t nan = TMath::QuietNaN();
-        return TVector3(nan, nan, nan);
+        return {nan, nan, nan};
     }
 
     pos = (1 / eDep) * pos;
@@ -157,7 +158,7 @@ TVector3 TRestGeant4Event::GetMeanPositionInVolume(Int_t volID) {
 ///
 /// \param volID Int_t specifying volume ID
 ///
-TVector3 TRestGeant4Event::GetPositionDeviationInVolume(Int_t volID) {
+TVector3 TRestGeant4Event::GetPositionDeviationInVolume(Int_t volID) const {
     TVector3 meanPos = this->GetMeanPositionInVolume(volID);
 
     Double_t nan = TMath::QuietNaN();
@@ -188,13 +189,12 @@ TVector3 TRestGeant4Event::GetPositionDeviationInVolume(Int_t volID) {
 ///
 /// \param volID Int_t specifying volume ID
 ///
-TVector3 TRestGeant4Event::GetFirstPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Event::GetFirstPositionInVolume(Int_t volID) const {
     for (int t = 0; t < GetNumberOfTracks(); t++)
-        if (GetTrack(t)->GetEnergyInVolume(volID) > 0) return GetTrack(t)->GetFirstPositionInVolume(volID);
+        if (GetTrack(t).GetEnergyInVolume(volID) > 0) return GetTrack(t).GetFirstPositionInVolume(volID);
 
-    TVector3 pos;
     Double_t nan = TMath::QuietNaN();
-    return TVector3(nan, nan, nan);
+    return {nan, nan, nan};
 }
 
 ///////////////////////////////////////////////
@@ -206,13 +206,12 @@ TVector3 TRestGeant4Event::GetFirstPositionInVolume(Int_t volID) {
 ///
 /// \param volID Int_t specifying volume ID
 ///
-TVector3 TRestGeant4Event::GetLastPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Event::GetLastPositionInVolume(Int_t volID) const {
     for (int t = GetNumberOfTracks() - 1; t >= 0; t--)
-        if (GetTrack(t)->GetEnergyInVolume(volID) > 0) return GetTrack(t)->GetLastPositionInVolume(volID);
+        if (GetTrack(t).GetEnergyInVolume(volID) > 0) return GetTrack(t).GetLastPositionInVolume(volID);
 
-    TVector3 pos;
     Double_t nan = TMath::QuietNaN();
-    return TVector3(nan, nan, nan);
+    return {nan, nan, nan};
 }
 
 TRestGeant4Track* TRestGeant4Event::GetTrackByID(int id) {
@@ -226,10 +225,10 @@ TRestGeant4Track* TRestGeant4Event::GetTrackByID(int id) {
 /// a specific volume is given as argument only the hits of that specific volume
 /// will be counted.
 ///
-Int_t TRestGeant4Event::GetNumberOfHits(Int_t volID) {
+Int_t TRestGeant4Event::GetNumberOfHits(Int_t volID) const {
     Int_t hits = 0;
     for (int i = 0; i < fNTracks; i++) {
-        hits += GetTrack(i)->GetNumberOfHits(volID);
+        hits += GetTrack(i).GetNumberOfHits(volID);
     }
     return hits;
 }
@@ -239,17 +238,17 @@ Int_t TRestGeant4Event::GetNumberOfHits(Int_t volID) {
 /// a specific volume is given as argument only the hits of that specific volume
 /// will be added to the TRestHits returned object.
 ///
-TRestHits TRestGeant4Event::GetHits(Int_t volID) {
+TRestHits TRestGeant4Event::GetHits(Int_t volID) const {
     TRestHits hits;
     for (int t = 0; t < fNTracks; t++) {
-        TRestGeant4Hits* g4Hits = GetTrack(t)->GetHits();
-        for (int n = 0; n < g4Hits->GetNumberOfHits(); n++) {
-            if (volID != -1 && g4Hits->GetVolumeId(n) != volID) continue;
+        const auto& g4Hits = GetTrack(t).GetHits();
+        for (int n = 0; n < g4Hits.GetNumberOfHits(); n++) {
+            if (volID != -1 && g4Hits.GetVolumeId(n) != volID) continue;
 
-            Double_t x = g4Hits->GetX(n);
-            Double_t y = g4Hits->GetY(n);
-            Double_t z = g4Hits->GetZ(n);
-            Double_t en = g4Hits->GetEnergy(n);
+            Double_t x = g4Hits.GetX(n);
+            Double_t y = g4Hits.GetY(n);
+            Double_t z = g4Hits.GetZ(n);
+            Double_t en = g4Hits.GetEnergy(n);
 
             hits.AddHit(x, y, z, en);
         }
@@ -258,18 +257,18 @@ TRestHits TRestGeant4Event::GetHits(Int_t volID) {
     return hits;
 }
 
-Int_t TRestGeant4Event::GetNumberOfTracksForParticle(TString parName) {
+Int_t TRestGeant4Event::GetNumberOfTracksForParticle(TString parName) const {
     Int_t tcks = 0;
     for (Int_t t = 0; t < GetNumberOfTracks(); t++)
-        if (GetTrack(t)->GetParticleName() == parName) tcks++;
+        if (GetTrack(t).GetParticleName() == parName) tcks++;
 
     return tcks;
 }
 
-Int_t TRestGeant4Event::GetEnergyDepositedByParticle(TString parName) {
+Int_t TRestGeant4Event::GetEnergyDepositedByParticle(TString parName) const {
     Double_t en = 0;
     for (Int_t t = 0; t < GetNumberOfTracks(); t++) {
-        if (GetTrack(t)->GetParticleName() == parName) en += GetTrack(t)->GetEnergy();
+        if (GetTrack(t).GetParticleName() == parName) en += GetTrack(t).GetEnergy();
     }
 
     return en;
@@ -295,15 +294,15 @@ void TRestGeant4Event::SetBoundaries() {
 
     Int_t nTHits = 0;
     for (int ntck = 0; ntck < this->GetNumberOfTracks(); ntck++) {
-        Int_t nHits = GetTrack(ntck)->GetNumberOfHits();
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        Int_t nHits = GetTrack(ntck).GetNumberOfHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
         for (int nhit = 0; nhit < nHits; nhit++) {
-            Double_t x = hits->GetX(nhit);
-            Double_t y = hits->GetY(nhit);
-            Double_t z = hits->GetZ(nhit);
+            Double_t x = hits.GetX(nhit);
+            Double_t y = hits.GetY(nhit);
+            Double_t z = hits.GetZ(nhit);
 
-            Double_t en = hits->GetEnergy(nhit);
+            Double_t en = hits.GetEnergy(nhit);
 
             if (x > maxX) maxX = x;
             if (x < minX) minX = x;
@@ -370,17 +369,17 @@ TMultiGraph* TRestGeant4Event::GetXYMultiGraph(Int_t gridElement, std::vector<TS
 
     Int_t cnt = 0;
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto hits = GetTrack(ntck).GetHits();
 
-        EColor color = GetTrack(ntck)->GetParticleColor();
+        EColor color = GetTrack(ntck).GetParticleColor();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t xPos = hits->GetX(nhit);
-            Double_t yPos = hits->GetY(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t xPos = hits.GetX(nhit);
+            Double_t yPos = hits.GetY(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             for (unsigned int p = 0; p < pcsList.size(); p++) {
-                if (GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)) == pcsList[p]) {
+                if (GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)) == pcsList[p]) {
                     TGraph* pcsGraph = new TGraph(1);
 
                     pcsGraph->SetPoint(0, xPos, yPos);
@@ -391,7 +390,7 @@ TMultiGraph* TRestGeant4Event::GetXYMultiGraph(Int_t gridElement, std::vector<TS
                     fXYPcsMarker.push_back(pcsGraph);
 
                     if (legendAdded[p] == 0) {
-                        fLegend_XY->AddEntry(pcsGraph, GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)),
+                        fLegend_XY->AddEntry(pcsGraph, GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)),
                                              "p");
                         legendAdded[p] = 1;
                     }
@@ -462,17 +461,17 @@ TMultiGraph* TRestGeant4Event::GetYZMultiGraph(Int_t gridElement, std::vector<TS
 
     Int_t cnt = 0;
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        EColor color = GetTrack(ntck)->GetParticleColor();
+        EColor color = GetTrack(ntck).GetParticleColor();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t yPos = hits->GetY(nhit);
-            Double_t zPos = hits->GetZ(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t yPos = hits.GetY(nhit);
+            Double_t zPos = hits.GetZ(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             for (unsigned int p = 0; p < pcsList.size(); p++) {
-                if (GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)) == pcsList[p]) {
+                if (GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)) == pcsList[p]) {
                     TGraph* pcsGraph = new TGraph(1);
 
                     pcsGraph->SetPoint(0, yPos, zPos);
@@ -483,7 +482,7 @@ TMultiGraph* TRestGeant4Event::GetYZMultiGraph(Int_t gridElement, std::vector<TS
                     fYZPcsMarker.push_back(pcsGraph);
 
                     if (legendAdded[p] == 0) {
-                        fLegend_YZ->AddEntry(pcsGraph, GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)),
+                        fLegend_YZ->AddEntry(pcsGraph, GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)),
                                              "p");
                         legendAdded[p] = 1;
                     }
@@ -554,17 +553,17 @@ TMultiGraph* TRestGeant4Event::GetXZMultiGraph(Int_t gridElement, std::vector<TS
 
     Int_t cnt = 0;
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        EColor color = GetTrack(ntck)->GetParticleColor();
+        EColor color = GetTrack(ntck).GetParticleColor();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t xPos = hits->GetX(nhit);
-            Double_t zPos = hits->GetZ(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t xPos = hits.GetX(nhit);
+            Double_t zPos = hits.GetZ(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             for (unsigned int p = 0; p < pcsList.size(); p++) {
-                if (GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)) == pcsList[p]) {
+                if (GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)) == pcsList[p]) {
                     TGraph* pcsGraph = new TGraph(1);
 
                     pcsGraph->SetPoint(0, xPos, zPos);
@@ -575,7 +574,7 @@ TMultiGraph* TRestGeant4Event::GetXZMultiGraph(Int_t gridElement, std::vector<TS
                     fXZPcsMarker.push_back(pcsGraph);
 
                     if (legendAdded[p] == 0) {
-                        fLegend_XZ->AddEntry(pcsGraph, GetTrack(ntck)->GetProcessName(hits->GetProcess(nhit)),
+                        fLegend_XZ->AddEntry(pcsGraph, GetTrack(ntck).GetProcessName(hits.GetProcess(nhit)),
                                              "p");
                         legendAdded[p] = 1;
                     }
@@ -637,12 +636,12 @@ TH2F* TRestGeant4Event::GetXYHistogram(Int_t gridElement, std::vector<TString> o
                         fMinY + pitch * nBinsY);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t xPos = hits->GetX(nhit);
-            Double_t yPos = hits->GetY(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t xPos = hits.GetX(nhit);
+            Double_t yPos = hits.GetY(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fXYHisto->Fill(xPos, yPos, energy);
         }
@@ -696,12 +695,12 @@ TH2F* TRestGeant4Event::GetXZHistogram(Int_t gridElement, std::vector<TString> o
                         fMinZ + pitch * nBinsZ);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t xPos = hits->GetX(nhit);
-            Double_t zPos = hits->GetZ(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t xPos = hits.GetX(nhit);
+            Double_t zPos = hits.GetZ(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fXZHisto->Fill(xPos, zPos, energy);
         }
@@ -755,12 +754,12 @@ TH2F* TRestGeant4Event::GetYZHistogram(Int_t gridElement, std::vector<TString> o
                         fMinZ + pitch * nBinsZ);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t yPos = hits->GetY(nhit);
-            Double_t zPos = hits->GetZ(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t yPos = hits.GetY(nhit);
+            Double_t zPos = hits.GetZ(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fYZHisto->Fill(yPos, zPos, energy);
         }
@@ -813,11 +812,11 @@ TH1D* TRestGeant4Event::GetXHistogram(Int_t gridElement, std::vector<TString> op
     fXHisto = new TH1D("X", "", nBinsX, fMinX - 10, fMinX + pitch * nBinsX);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t xPos = hits->GetX(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t xPos = hits.GetX(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fXHisto->Fill(xPos, energy);
         }
@@ -864,11 +863,11 @@ TH1D* TRestGeant4Event::GetZHistogram(Int_t gridElement, std::vector<TString> op
     fZHisto = new TH1D("Z", "", nBinsZ, fMinZ - 10, fMinZ + pitch * nBinsZ);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t zPos = hits->GetZ(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t zPos = hits.GetZ(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fZHisto->Fill(zPos, energy);
         }
@@ -915,11 +914,11 @@ TH1D* TRestGeant4Event::GetYHistogram(Int_t gridElement, std::vector<TString> op
     fYHisto = new TH1D("Y", "", nBinsY, fMinY - 10, fMinY + pitch * nBinsY);
 
     for (int ntck = 0; ntck < GetNumberOfTracks(); ntck++) {
-        TRestGeant4Hits* hits = GetTrack(ntck)->GetHits();
+        const auto& hits = GetTrack(ntck).GetHits();
 
-        for (int nhit = 0; nhit < hits->GetNumberOfHits(); nhit++) {
-            Double_t yPos = hits->GetY(nhit);
-            Double_t energy = hits->GetEnergy(nhit);
+        for (int nhit = 0; nhit < hits.GetNumberOfHits(); nhit++) {
+            Double_t yPos = hits.GetY(nhit);
+            Double_t energy = hits.GetEnergy(nhit);
 
             fYHisto->Fill(yPos, energy);
         }
@@ -1110,7 +1109,7 @@ TPad* TRestGeant4Event::DrawEvent(TString option, Bool_t autoBoundaries) {
 
     return fPad;
 }
-void TRestGeant4Event::PrintActiveVolumes() {
+void TRestGeant4Event::PrintActiveVolumes() const {
     cout << "Number of active volumes : " << GetNumberOfActiveVolumes() << endl;
     for (int i = 0; i < fVolumeStoredNames.size(); i++) {
         if (isVolumeStored(i)) {
@@ -1121,7 +1120,7 @@ void TRestGeant4Event::PrintActiveVolumes() {
             cout << "Active volume " << i << ":" << fVolumeStoredNames[i] << " has not been stored" << endl;
     }
 }
-void TRestGeant4Event::PrintEvent(int maxTracks, int maxHits) {
+void TRestGeant4Event::PrintEvent(int maxTracks, int maxHits) const {
     TRestEvent::PrintEvent();
 
     cout.precision(4);
@@ -1132,7 +1131,7 @@ void TRestGeant4Event::PrintEvent(int maxTracks, int maxHits) {
          << fPrimaryEventOrigin.Z() << ") mm" << endl;
 
     for (int n = 0; n < GetNumberOfPrimaries(); n++) {
-        TVector3* dir = &fPrimaryEventDirection[n];
+        const auto dir = &fPrimaryEventDirection[n];
         cout << "Source " << n << " Particle name : " << GetPrimaryEventParticleName(n) << endl;
         cout << "Source " << n << " direction : (" << dir->X() << "," << dir->Y() << "," << dir->Z() << ")"
              << endl;
@@ -1162,7 +1161,7 @@ void TRestGeant4Event::PrintEvent(int maxTracks, int maxHits) {
         cout << " Printing only the first " << ntracks << " tracks" << endl;
     }
 
-    for (int n = 0; n < ntracks; n++) GetTrack(n)->PrintTrack(maxHits);
+    for (int n = 0; n < ntracks; n++) GetTrack(n).PrintTrack(maxHits);
 }
 
 void TRestGeant4Event::InitializePerProcessEnergyInSensitive() {
@@ -1180,26 +1179,24 @@ void TRestGeant4Event::InitializePerProcessEnergyInSensitive() {
 
     std::string volume_name;
     std::string process_name;
-    TRestGeant4Track* track;
-    TRestGeant4Hits* hits;
     Double_t energy;
 
     for (Int_t track_id = 0; track_id < GetNumberOfTracks(); track_id++) {
-        track = GetTrack(track_id);
+        const auto& track = GetTrack(track_id);
 
-        if (track->GetEnergyInVolume(0) == 0) {
+        if (track.GetEnergyInVolume(0) == 0) {
             continue;
         }
 
-        hits = track->GetHits();
+        const auto& hits = track.GetHits();
 
-        for (Int_t hit_id = 0; hit_id < hits->GetNumberOfHits(); hit_id++) {
-            if (hits->GetVolumeId(hit_id) != 0) {
+        for (Int_t hit_id = 0; hit_id < hits.GetNumberOfHits(); hit_id++) {
+            if (hits.GetVolumeId(hit_id) != 0) {
                 continue;
             }
 
-            process_name = (std::string)track->GetProcessName(hits->GetHitProcess(hit_id));
-            energy = hits->GetEnergy(hit_id);
+            process_name = (std::string)track.GetProcessName(hits.GetHitProcess(hit_id));
+            energy = hits.GetEnergy(hit_id);
             if (process_name == "phot") {
                 PerProcessEnergyInSensitive["photoelectric"] += energy;
             } else if (process_name == "compt") {
@@ -1208,26 +1205,26 @@ void TRestGeant4Event::InitializePerProcessEnergyInSensitive() {
                 PerProcessEnergyInSensitive["electron_ionization"] += energy;
             } else if (process_name == "ionIoni") {
                 PerProcessEnergyInSensitive["ion_ionization"] += energy;
-                if (track->GetParticleName() == "alpha") {
+                if (track.GetParticleName() == "alpha") {
                     PerProcessEnergyInSensitive["alpha_ionization"] += energy;
                 }
             } else if (process_name == "msc") {
                 PerProcessEnergyInSensitive["msc"] += energy;
             } else if (process_name == "hIoni") {
                 PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
-                if (track->GetParticleName() == "proton") {
+                if (track.GetParticleName() == "proton") {
                     PerProcessEnergyInSensitive["proton_ionization"] += energy;
                 }
             } else if (process_name == "hadElastic") {
                 PerProcessEnergyInSensitive["hadronic_elastic"] += energy;
-                if (track->GetParticleName() == "neutron") {
+                if (track.GetParticleName() == "neutron") {
                     PerProcessEnergyInSensitive["neutron_elastic"] += energy;
                 }
             } else if (process_name == "Transportation") {
-                if (track->GetParticleName() == "proton") {
+                if (track.GetParticleName() == "proton") {
                     PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
                     PerProcessEnergyInSensitive["proton_ionization"] += energy;
-                } else if (track->GetParticleName() == "e-" || track->GetParticleName() == "e+") {
+                } else if (track.GetParticleName() == "e-" || track.GetParticleName() == "e+") {
                     PerProcessEnergyInSensitive["electron_ionization"] += energy;
                 }
             }

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -257,7 +257,7 @@ TRestHits TRestGeant4Event::GetHits(Int_t volID) const {
     return hits;
 }
 
-Int_t TRestGeant4Event::GetNumberOfTracksForParticle(TString parName) const {
+Int_t TRestGeant4Event::GetNumberOfTracksForParticle(const TString& parName) const {
     Int_t tcks = 0;
     for (Int_t t = 0; t < GetNumberOfTracks(); t++)
         if (GetTrack(t).GetParticleName() == parName) tcks++;
@@ -265,7 +265,7 @@ Int_t TRestGeant4Event::GetNumberOfTracksForParticle(TString parName) const {
     return tcks;
 }
 
-Int_t TRestGeant4Event::GetEnergyDepositedByParticle(TString parName) const {
+Int_t TRestGeant4Event::GetEnergyDepositedByParticle(const TString& parName) const {
     Double_t en = 0;
     for (Int_t t = 0; t < GetNumberOfTracks(); t++) {
         if (GetTrack(t).GetParticleName() == parName) en += GetTrack(t).GetEnergy();
@@ -1006,7 +1006,7 @@ TH1D* TRestGeant4Event::GetYHistogram(Int_t gridElement, std::vector<TString> op
 /// DrawEvent("graphXZ:graphYZ:histXZ(Cont0,colz):histYZ(Cont0,colz)")
 /// \endcode
 ///
-TPad* TRestGeant4Event::DrawEvent(TString option, Bool_t autoBoundaries) {
+TPad* TRestGeant4Event::DrawEvent(const TString& option, Bool_t autoBoundaries) {
     vector<TString> optList = Vector_cast<string, TString>(TRestTools::GetOptions((string)option));
 
     if (autoBoundaries) SetBoundaries();

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -1164,3 +1164,73 @@ void TRestGeant4Event::PrintEvent(int maxTracks, int maxHits) {
 
     for (int n = 0; n < ntracks; n++) GetTrack(n)->PrintTrack(maxHits);
 }
+
+void TRestGeant4Event::InitializePerProcessEnergyInSensitive() {
+    PerProcessEnergyInitFlag = true;
+    PerProcessEnergyInSensitive["photoelectric"] = 0;
+    PerProcessEnergyInSensitive["compton"] = 0;
+    PerProcessEnergyInSensitive["electron_ionization"] = 0;
+    PerProcessEnergyInSensitive["ion_ionization"] = 0;
+    PerProcessEnergyInSensitive["alpha_ionization"] = 0;
+    PerProcessEnergyInSensitive["msc"] = 0;
+    PerProcessEnergyInSensitive["hadronic_ionization"] = 0;
+    PerProcessEnergyInSensitive["proton_ionization"] = 0;
+    PerProcessEnergyInSensitive["hadronic_elastic"] = 0;
+    PerProcessEnergyInSensitive["neutron_elastic"] = 0;
+
+    std::string volume_name;
+    std::string process_name;
+    TRestGeant4Track* track;
+    TRestGeant4Hits* hits;
+    Double_t energy;
+
+    for (Int_t track_id = 0; track_id < GetNumberOfTracks(); track_id++) {
+        track = GetTrack(track_id);
+
+        if (track->GetEnergyInVolume(0) == 0) {
+            continue;
+        }
+
+        hits = track->GetHits();
+
+        for (Int_t hit_id = 0; hit_id < hits->GetNumberOfHits(); hit_id++) {
+            if (hits->GetVolumeId(hit_id) != 0) {
+                continue;
+            }
+
+            process_name = (std::string)track->GetProcessName(hits->GetHitProcess(hit_id));
+            energy = hits->GetEnergy(hit_id);
+            if (process_name == "phot") {
+                PerProcessEnergyInSensitive["photoelectric"] += energy;
+            } else if (process_name == "compt") {
+                PerProcessEnergyInSensitive["compton"] += energy;
+            } else if (process_name == "eIoni" || process_name == "e-Step" || process_name == "e+Step") {
+                PerProcessEnergyInSensitive["electron_ionization"] += energy;
+            } else if (process_name == "ionIoni") {
+                PerProcessEnergyInSensitive["ion_ionization"] += energy;
+                if (track->GetParticleName() == "alpha") {
+                    PerProcessEnergyInSensitive["alpha_ionization"] += energy;
+                }
+            } else if (process_name == "msc") {
+                PerProcessEnergyInSensitive["msc"] += energy;
+            } else if (process_name == "hIoni") {
+                PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
+                if (track->GetParticleName() == "proton") {
+                    PerProcessEnergyInSensitive["proton_ionization"] += energy;
+                }
+            } else if (process_name == "hadElastic") {
+                PerProcessEnergyInSensitive["hadronic_elastic"] += energy;
+                if (track->GetParticleName() == "neutron") {
+                    PerProcessEnergyInSensitive["neutron_elastic"] += energy;
+                }
+            } else if (process_name == "Transportation") {
+                if (track->GetParticleName() == "proton") {
+                    PerProcessEnergyInSensitive["hadronic_ionization"] += energy;
+                    PerProcessEnergyInSensitive["proton_ionization"] += energy;
+                } else if (track->GetParticleName() == "e-" || track->GetParticleName() == "e+") {
+                    PerProcessEnergyInSensitive["electron_ionization"] += energy;
+                }
+            }
+        }
+    }
+}

--- a/src/TRestGeant4EventViewer.cxx
+++ b/src/TRestGeant4EventViewer.cxx
@@ -48,18 +48,16 @@ void TRestGeant4EventViewer::AddEvent(TRestEvent* ev) {
 
     fG4Event = (TRestGeant4Event*)ev;
 
-    TRestGeant4Track* g4Track;
-
     Double_t eDepMin = 1.e6;
     Double_t eDepMax = 0;
     Double_t totalEDep = 0;
 
     for (int i = 0; i < fG4Event->GetNumberOfTracks(); i++) {
-        g4Track = fG4Event->GetTrack(i);
-        TRestGeant4Hits* g4Hits = g4Track->GetHits();
-        Int_t nHits = g4Track->GetNumberOfHits();
+        const auto& g4Track = fG4Event->GetTrack(i);
+        const auto& g4Hits = g4Track.GetHits();
+        Int_t nHits = g4Track.GetNumberOfHits();
         for (int j = 0; j < nHits; j++) {
-            Double_t eDep = g4Hits->GetEnergy(j);
+            Double_t eDep = g4Hits.GetEnergy(j);
             if (eDep > eDepMax) eDepMax = eDep;
             if (eDep < eDepMin) eDepMin = eDep;
 
@@ -76,7 +74,7 @@ void TRestGeant4EventViewer::AddEvent(TRestEvent* ev) {
 
     Int_t textAdded = 0;
     for (int trkID = 1; trkID < fG4Event->GetNumberOfTracks() + 1; trkID++) {
-        g4Track = fG4Event->GetTrackByID(trkID);
+        const auto& g4Track = fG4Event->GetTrackByID(trkID);
 
         Int_t parentID = g4Track->GetParentID();
         TVector3 origin = g4Track->GetTrackOrigin();
@@ -116,18 +114,18 @@ void TRestGeant4EventViewer::AddEvent(TRestEvent* ev) {
         // cout << "Adding marker" << endl;
         this->AddMarker(trkID, origin, markerStr);
 
-        TRestGeant4Hits* g4Hits = g4Track->GetHits();
+        const auto& g4Hits = g4Track->GetHits();
         Int_t nHits = g4Track->GetNumberOfHits();
 
         // cout << "Adding hits" << endl;
         for (int i = 0; i < nHits; i++) {
-            Double_t x = g4Hits->GetX(i);
-            Double_t y = g4Hits->GetY(i);
-            Double_t z = g4Hits->GetZ(i);
+            Double_t x = g4Hits.GetX(i);
+            Double_t y = g4Hits.GetY(i);
+            Double_t z = g4Hits.GetZ(i);
 
             this->NextTrackVertex(trkID, TVector3(x, y, z));
 
-            Double_t eDep = g4Hits->GetEnergy(i);
+            Double_t eDep = g4Hits.GetEnergy(i);
 
             if (eDep > 0) {
                 Double_t radius = slope * eDep + bias;

--- a/src/TRestGeant4Hits.cxx
+++ b/src/TRestGeant4Hits.cxx
@@ -68,7 +68,7 @@ void TRestGeant4Hits::RemoveG4Hits() {
     fKineticEnergy.Set(0);
 }
 
-Double_t TRestGeant4Hits::GetEnergyInVolume(Int_t volID) {
+Double_t TRestGeant4Hits::GetEnergyInVolume(Int_t volID) const {
     Double_t en = 0;
 
     for (int n = 0; n < fNHits; n++)
@@ -77,7 +77,7 @@ Double_t TRestGeant4Hits::GetEnergyInVolume(Int_t volID) {
     return en;
 }
 
-TVector3 TRestGeant4Hits::GetMeanPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Hits::GetMeanPositionInVolume(Int_t volID) const {
     TVector3 pos;
     Double_t en = 0;
     for (int n = 0; n < fNHits; n++)
@@ -87,29 +87,26 @@ TVector3 TRestGeant4Hits::GetMeanPositionInVolume(Int_t volID) {
         }
 
     if (en == 0) {
-        TVector3 pos;
         Double_t nan = TMath::QuietNaN();
-        return TVector3(nan, nan, nan);
+        return {nan, nan, nan};
     }
 
     pos = (1. / en) * pos;
     return pos;
 }
 
-TVector3 TRestGeant4Hits::GetFirstPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Hits::GetFirstPositionInVolume(Int_t volID) const {
     for (int n = 0; n < fNHits; n++)
         if (fVolumeID[n] == volID) return GetPosition(n);
 
-    TVector3 pos;
     Double_t nan = TMath::QuietNaN();
-    return TVector3(nan, nan, nan);
+    return {nan, nan, nan};
 }
 
-TVector3 TRestGeant4Hits::GetLastPositionInVolume(Int_t volID) {
+TVector3 TRestGeant4Hits::GetLastPositionInVolume(Int_t volID) const {
     for (int n = fNHits - 1; n >= 0; n--)
         if (fVolumeID[n] == volID) return GetPosition(n);
 
-    TVector3 pos;
     Double_t nan = TMath::QuietNaN();
-    return TVector3(nan, nan, nan);
+    return {nan, nan, nan};
 }

--- a/src/TRestGeant4Track.cxx
+++ b/src/TRestGeant4Track.cxx
@@ -145,7 +145,7 @@ Int_t TRestGeant4Track::GetProcessID(TString pcsName) {
     return id;
 }
 
-EColor TRestGeant4Track::GetParticleColor() {
+EColor TRestGeant4Track::GetParticleColor() const {
     EColor color = kGray;
 
     if (GetParticleName() == "e-")
@@ -171,7 +171,7 @@ EColor TRestGeant4Track::GetParticleColor() {
 /// the TRestGeant4Track. If a specific volume id is given as argument only
 /// the hits of that specific volume will be counted.
 ///
-Int_t TRestGeant4Track::GetNumberOfHits(Int_t volID) {
+Int_t TRestGeant4Track::GetNumberOfHits(Int_t volID) const {
     Int_t hits = 0;
     for (int n = 0; n < fHits.GetNumberOfHits(); n++) {
         if (volID != -1 && fHits.GetVolumeId(n) != volID) continue;
@@ -193,7 +193,7 @@ Double_t TRestGeant4Track::GetTrackLength() {
     return length;
 }
 
-TString TRestGeant4Track::GetProcessName(Int_t id) {
+TString TRestGeant4Track::GetProcessName(Int_t id) const {
     if (id == 0)
         return "initStep";
     else if (id == 1)
@@ -301,7 +301,7 @@ TString TRestGeant4Track::GetProcessName(Int_t id) {
     return "";
 }
 
-void TRestGeant4Track::PrintTrack(int maxHits) {
+void TRestGeant4Track::PrintTrack(int maxHits) const {
     cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
             "++++++++++++"
          << endl;
@@ -324,13 +324,12 @@ void TRestGeant4Track::PrintTrack(int maxHits) {
         cout << " Printing only the first " << nHits << " hits of the track" << endl;
     }
 
-    TRestGeant4Hits* hits = GetHits();
     for (int i = 0; i < nHits; i++) {
-        cout << " # Hit " << i << " # process : " << GetProcessName(hits->GetHitProcess(i))
-             << " volume : " << hits->GetHitVolume(i) << " X : " << hits->GetX(i) << " Y : " << hits->GetY(i)
-             << " Z : " << hits->GetZ(i) << " mm" << endl;
-        cout << " Edep : " << hits->GetEnergy(i) << " keV Ekin : " << hits->GetKineticEnergy(i) << " keV"
-             << " Global time : " << hits->GetTime(i) << " us" << endl;
+        cout << " # Hit " << i << " # process : " << GetProcessName(fHits.GetHitProcess(i))
+             << " volume : " << fHits.GetHitVolume(i) << " X : " << fHits.GetX(i) << " Y : " << fHits.GetY(i)
+             << " Z : " << fHits.GetZ(i) << " mm" << endl;
+        cout << " Edep : " << fHits.GetEnergy(i) << " keV Ekin : " << fHits.GetKineticEnergy(i) << " keV"
+             << " Global time : " << fHits.GetTime(i) << " us" << endl;
     }
     cout << endl;
     cout.precision(2);

--- a/src/TRestGeant4Track.cxx
+++ b/src/TRestGeant4Track.cxx
@@ -29,7 +29,7 @@ TRestGeant4Track::~TRestGeant4Track() {
     // TRestGeant4Track destructor
 }
 
-Int_t TRestGeant4Track::GetProcessID(TString pcsName) {
+Int_t TRestGeant4Track::GetProcessID(const TString& pcsName) {
     Int_t id = -1;
 
     // TODO We register the process manually. Not good if we add new processes to
@@ -180,7 +180,7 @@ Int_t TRestGeant4Track::GetNumberOfHits(Int_t volID) const {
     return hits;
 }
 
-Double_t TRestGeant4Track::GetTrackLength() {
+Double_t TRestGeant4Track::GetTrackLength() const {
     Double_t length = 0;
 
     length = GetDistance(fHits.GetPosition(0), GetTrackOrigin());

--- a/src/TRestGeant4VetoAnalysisProcess.cxx
+++ b/src/TRestGeant4VetoAnalysisProcess.cxx
@@ -212,16 +212,16 @@ TRestEvent* TRestGeant4VetoAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
         volume_energy_map.clear();
         for (int i = 0; i < fOutputG4Event->GetNumberOfTracks(); i++) {
             auto track = fOutputG4Event->GetTrack(i);
-            string particle_name = (string)track->GetParticleName();
+            string particle_name = (string)track.GetParticleName();
             for (const auto& id : fVetoVolumeIds) {
                 string volume_name = (string)fG4Metadata->GetActiveVolumeName(id);
 
                 if (particle_name == "e-" || particle_name == "e+" || particle_name == "gamma") {
                     // no quenching factor
-                    volume_energy_map[volume_name] += track->GetEnergyInVolume(id);
+                    volume_energy_map[volume_name] += track.GetEnergyInVolume(id);
                 } else {
                     // apply quenching factor
-                    volume_energy_map[volume_name] += quenching_factor * track->GetEnergyInVolume(id);
+                    volume_energy_map[volume_name] += quenching_factor * track.GetEnergyInVolume(id);
                 }
             }
         }


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![lobis](https://badgen.net/badge/Author/lobis/blue) ![492](https://badgen.net/badge/Size/492/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-add-const-to-getters/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-add-const-to-getters)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently very few methods in the framework are marked as `const`. I have tried in the past to make the methods related to the event / track / hits const but its impossible unless you basically make all of them const, since they call each other multiple times, especially methods such as `GetTrack` etc. This is also why this PR is very large.

This PR makes the necessary changes in Geant4Lib so that the getters on `TRestGeant4Event`, `TRestGeant4Track` and `TRestGeant4Hits` are marked as `const`.

In order to do this I had to also modify:

* https://github.com/rest-for-physics/framework/pull/174
* https://github.com/rest-for-physics/connectorslib/pull/10
* https://github.com/rest-for-physics/restG4/pull/38

I only had to introduce a significant change to the framework: methods such as `TRestGeant4Event::GetTrack` or `TRestGeant4Track::GetHits` now return a constant reference. Previously they returned a pointer, but this is incompatible with having all getters marked as `const` and it makes little sense in my opinion.

This means that before you wrote:

```TRestGeant4Track* event.GetTrack();```

and now you write:

```TRestGeant4Track event.GetTrack();```

in 99% of usage its not necessary to modify this returned track, as you generally use it for analysis. I only found one instance where its necessary to modify it, on the `restG4` package. I created the method `TRestGeant4Event::GetTrackPointer` which works as the previous `GetTrack` to solve this issue.

