### PR TITLE
Fixed activeVolume for assemblies

### DIFF
--- a/inc/TRestGeant4GeometryInfo.h
+++ b/inc/TRestGeant4GeometryInfo.h
@@ -15,13 +15,16 @@
 class G4VPhysicalVolume;
 
 class TRestGeant4GeometryInfo {
-    ClassDef(TRestGeant4GeometryInfo, 1);
+    ClassDef(TRestGeant4GeometryInfo, 2);
 
    private:
     bool fIsAssembly = false;
 
    public:
+    // Insertion order is important for GDML containers. These containers are filled from GDML only not Geant4
     std::vector<TString> fGdmlNewPhysicalNames;
+    std::vector<TString> fGdmlLogicalNames;
+
     std::map<TString, TString>
         fGeant4PhysicalNameToNewPhysicalNameMap; /*
                                                   * only makes sense when using assembly

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -380,18 +380,17 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     /// \brief Returns the number of biasing volumes defined. If 0 the biasing technique
     /// is not being used.
-    Int_t isBiasingActive() { return fBiasingVolumes.size(); }
+    inline Int_t isBiasingActive() const { return fBiasingVolumes.size(); }
 
     /// Returns a std::string with the name of the sensitive volume.
     TString GetSensitiveVolume() { return fSensitiveVolume; }
 
     /// Sets the name of the sensitive volume
-    void SetSensitiveVolume(TString sensVol) { fSensitiveVolume = sensVol; }
-    ///////////////////////////////////////////////////////////
+    inline void SetSensitiveVolume(const TString& sensitiveVolume) { fSensitiveVolume = sensitiveVolume; }
 
     /// \brief Returns the probability per event to register (write to disk) hits in the
     /// storage volume with index n.
-    Double_t GetStorageChance(Int_t n) { return fChance[n]; }
+    inline Double_t GetStorageChance(Int_t n) { return fChance[n]; }
 
     /// Returns the probability per event to register (write to disk) hits in a
     /// GDML volume given its geometry name.
@@ -400,26 +399,26 @@ class TRestGeant4Metadata : public TRestMetadata {
     Double_t GetMaxStepSize(TString vol);
 
     /// Returns the minimum event energy required for an event to be stored.
-    Double_t GetMinimumEnergyStored() { return fEnergyRangeStored.X(); }
+    inline Double_t GetMinimumEnergyStored() const { return fEnergyRangeStored.X(); }
 
     /// Returns the maximum event energy required for an event to be stored.
-    Double_t GetMaximumEnergyStored() { return fEnergyRangeStored.Y(); }
+    inline Double_t GetMaximumEnergyStored() const { return fEnergyRangeStored.Y(); }
 
     /// \brief Returns the number of active volumes, or geometry volumes that have been
     /// selected for data storage.
-    Int_t GetNumberOfActiveVolumes() { return fActiveVolumes.size(); }
+    inline Int_t GetNumberOfActiveVolumes() const { return fActiveVolumes.size(); }
 
     /// Returns a std::string with the name of the active volume with index n
-    TString GetActiveVolumeName(Int_t n) { return fActiveVolumes[n]; }
+    inline TString GetActiveVolumeName(Int_t n) { return fActiveVolumes[n]; }
 
     /// Returns the world magnetic field in Tesla
-    TVector3 GetMagneticField() { return fMagneticField; }
+    inline TVector3 GetMagneticField() const { return fMagneticField; }
 
     Int_t GetActiveVolumeID(TString name);
 
     Bool_t isVolumeStored(TString volName);
 
-    void SetActiveVolume(TString name, Double_t chance, Double_t maxStep = 0);
+    void SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep = 0);
 
     void PrintMetadata();
 

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -63,7 +63,7 @@ extern std::map<std::string, generator_types> generator_types_map;
 enum class generator_shapes {
     GDML,
     WALL,
-    PLATE,
+    CIRCLE,
     BOX,
     SPHERE,
     CYLINDER,
@@ -153,7 +153,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// box: length, width, height
     /// sphere: radius
     /// wall: length, width
-    /// plate: radius
+    /// circle: radius
     /// cylinder: radius, length
     TVector3 fGenSize;
 

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -102,14 +102,6 @@ class TRestGeant4Metadata : public TRestMetadata {
     void ReadStorage();
     void ReadBiasing();
 
-    // void ReadEventDataFile(TString fName);
-
-    // Int_t ReadNewDecay0File(TString fileName);
-
-    // Int_t ReadOldDecay0File(TString fileName);
-
-    // void ReadParticleSource(TiXmlElement* sourceDefinition);
-
     /// Class used to store and retrieve geometry info
     TRestGeant4GeometryInfo fGeant4GeometryInfo;
 
@@ -227,141 +219,141 @@ class TRestGeant4Metadata : public TRestMetadata {
    public:
     /// \brief Returns the random seed that was used to generate the corresponding
     /// geant4 dataset.
-    Long_t GetSeed() const { return fSeed; }
+    inline Long_t GetSeed() const { return fSeed; }
 
     /// \brief Returns a reference to the geometry info
-    TRestGeant4GeometryInfo* GetGeant4GeometryInfo() { return &fGeant4GeometryInfo; }
+    inline TRestGeant4GeometryInfo* GetGeant4GeometryInfo() { return &fGeant4GeometryInfo; }
 
     /// \brief Returns a std::string with the version of Geant4 used on the event data
     /// simulation
-    TString GetGeant4Version() const { return fGeant4Version; }
+    inline TString GetGeant4Version() const { return fGeant4Version; }
 
     size_t GetGeant4VersionMajor() const;
 
     /// Returns the local path to the GDML geometry
-    TString GetGeometryPath() const { return fGeometryPath; }
+    inline TString GetGeometryPath() const { return fGeometryPath; }
 
     /// Returns the main filename of the GDML geometry
-    TString GetGdmlFilename() const { return fGdmlFilename; }
+    inline TString GetGdmlFilename() const { return fGdmlFilename; }
 
     /// Returns the reference provided at the GDML file header
-    TString GetGdmlReference() const { return fGdmlReference; }
+    inline TString GetGdmlReference() const { return fGdmlReference; }
 
     /// Returns the reference provided at the materials file header
-    TString GetMaterialsReference() const { return fMaterialsReference; }
+    inline TString GetMaterialsReference() const { return fMaterialsReference; }
 
     /// \brief Returns a std::string specifying the generator type (volume, surface, point,
     /// virtualWall, etc )
-    TString GetGeneratorType() const { return fGenType; }
+    inline TString GetGeneratorType() const { return fGenType; }
 
     /// \brief Returns a std::string specifying the generator shape (point, wall, box, etc )
-    TString GetGeneratorShape() const { return fGenShape; }
+    inline TString GetGeneratorShape() const { return fGenShape; }
 
     /// \brief Returns the name of the GDML volume where primary events are
     /// produced. This value has meaning only when using volume or surface
     /// generator types.
-    TString GetGeneratedFrom() const { return fGenFrom; }
+    inline TString GetGeneratedFrom() const { return fGenFrom; }
 
     /// \brief Returns the name of the GDML volume where primary events are
     /// produced. This value has meaning only when using volume or surface
     /// generator types.
-    TString GetGDMLGeneratorVolume() const { return fGenFrom; }
+    inline TString GetGDMLGeneratorVolume() const { return fGenFrom; }
 
     /// \brief Returns a 3d-std::vector with the position of the primary event
     /// generator. This value has meaning only when using point and virtual
     /// generator types.
-    TVector3 GetGeneratorPosition() const { return fGenPosition; }
+    inline TVector3 GetGeneratorPosition() const { return fGenPosition; }
 
     /// \brief Returns a 3d-std::vector, fGenRotation, with the XYZ rotation angle
     /// values in degrees. This value is used by virtualWall, virtualCircleWall
     /// and virtualCylinder generator types.
-    TVector3 GetGeneratorRotationAxis() const { return fGenRotationAxis; }
+    inline TVector3 GetGeneratorRotationAxis() const { return fGenRotationAxis; }
 
     /// \brief Returns the degree of rotation
-    Double_t GetGeneratorRotationDegree() const { return fGenRotationDegree; }
+    inline Double_t GetGeneratorRotationDegree() const { return fGenRotationDegree; }
 
     /// \brief Returns the main spatial dimension of virtual generator.
     /// It is the size of a  virtualBox.
-    TVector3 GetGeneratorSize() const { return fGenSize; }
+    inline TVector3 GetGeneratorSize() const { return fGenSize; }
 
     /// \brief Returns the density function of the generator
-    TString GetGeneratorSpatialDensity() const { return fGenDensityFunction; }
+    inline TString GetGeneratorSpatialDensity() const { return fGenDensityFunction; }
 
     /// \brief Returns true in case full decay chain simulation is enabled.
-    Bool_t isFullChainActivated() const { return fFullChain; }
+    inline Bool_t isFullChainActivated() const { return fFullChain; }
 
     /// \brief Returns the value of the maximum Geant4 step size in mm for the
     /// target volume.
-    Double_t GetMaxTargetStepSize() const { return fMaxTargetStepSize; }
+    inline Double_t GetMaxTargetStepSize() const { return fMaxTargetStepSize; }
 
     /// \brief Returns the time gap, in us, required to consider a Geant4 hit as a
     /// new independent event. It is used to separate simulated events that in
     /// practice will appear as such in our detector. I.e. to separate multiple
     /// decay products (sometimes with years time delays) into independent events.
-    Double_t GetSubEventTimeDelay() const { return fSubEventTimeDelay; }
+    inline Double_t GetSubEventTimeDelay() const { return fSubEventTimeDelay; }
 
     /// It returns true if save all events is active
-    Bool_t GetSaveAllEvents() const { return fSaveAllEvents; }
+    inline Bool_t GetSaveAllEvents() const { return fSaveAllEvents; }
 
     /// It returns true if `printProgress` parameter was set to true
-    Bool_t PrintProgress() const { return fPrintProgress; }
+    inline Bool_t PrintProgress() const { return fPrintProgress; }
 
     /// It returns false if `registerEmptyTracks` parameter was set to false.
-    Bool_t RegisterEmptyTracks() const { return fRegisterEmptyTracks; }
+    inline Bool_t RegisterEmptyTracks() const { return fRegisterEmptyTracks; }
 
     /// \brief Used exclusively by restG4 to set the value of the random seed used on
     /// Geant4 simulation.
-    void SetSeed(Long_t seed) { fSeed = seed; }
+    inline void SetSeed(Long_t seed) { fSeed = seed; }
 
     /// Enables or disables the save all events feature
-    void SetSaveAllEvents(const Bool_t value) { fSaveAllEvents = value; }
+    inline void SetSaveAllEvents(const Bool_t value) { fSaveAllEvents = value; }
 
     /// Sets the value of the Geant4 version
     inline void SetGeant4Version(const TString& versionString) { fGeant4Version = versionString; }
 
     ///  \brief Sets the generator type. I.e. volume, surface, point, virtualWall,
     ///  virtualCylinder, etc.
-    void SetGeneratorType(TString type) { fGenType = type; }
+    inline void SetGeneratorType(TString type) { fGenType = type; }
 
     ///  \brief Sets the generator main spatial dimension. In a virtual generator is the
     ///  radius of cylinder, size of wall, etc.
-    void SetGeneratorSize(const TVector3& size) { fGenSize = size; }
+    inline void SetGeneratorSize(const TVector3& size) { fGenSize = size; }
 
     ///  Enables/disables the full chain decay generation.
-    void SetFullChain(Bool_t fullChain) { fFullChain = fullChain; }
+    inline void SetFullChain(Bool_t fullChain) { fFullChain = fullChain; }
 
     ///  Sets the position of the virtual generator using a TVector3.
-    void SetGeneratorPosition(const TVector3& pos) { fGenPosition = pos; }
+    inline void SetGeneratorPosition(const TVector3& pos) { fGenPosition = pos; }
 
     ///  Sets the position of the virtual generator using x,y,z coordinates.
-    void SetGeneratorPosition(double x, double y, double z) { fGenPosition = TVector3(x, y, z); }
+    inline void SetGeneratorPosition(double x, double y, double z) { fGenPosition = TVector3(x, y, z); }
 
     /// Sets the number of events to be simulated.
-    void SetNEvents(Int_t n) { fNEvents = n; }
+    inline void SetNEvents(Int_t n) { fNEvents = n; }
 
     /// It sets the location of the geometry files
-    void SetGeometryPath(std::string path) { fGeometryPath = path; }
+    inline void SetGeometryPath(std::string path) { fGeometryPath = path; }
 
     /// It sets the main filename to be used for the GDML geometry
-    void SetGdmlFilename(std::string gdmlFile) { fGdmlFilename = gdmlFile; }
+    inline void SetGdmlFilename(std::string gdmlFile) { fGdmlFilename = gdmlFile; }
 
     /// Returns the reference provided at the GDML file header
-    void SetGdmlReference(std::string reference) { fGdmlReference = reference; }
+    inline void SetGdmlReference(std::string reference) { fGdmlReference = reference; }
 
     /// Returns the reference provided at the materials file header
-    void SetMaterialsReference(std::string reference) { fMaterialsReference = reference; }
+    inline void SetMaterialsReference(std::string reference) { fMaterialsReference = reference; }
 
     /// Returns the number of events to be simulated.
-    Int_t GetNumberOfEvents() const { return fNEvents; }
+    inline Int_t GetNumberOfEvents() const { return fNEvents; }
     ///////////////////////////////////////////////////////////
 
     // Direct access to sources definition in primary generator
     ///////////////////////////////////////////////////////////
     /// Returns the number of primary event sources defined in the generator.
-    Int_t GetNumberOfSources() const { return fParticleSource.size(); }
+    inline Int_t GetNumberOfSources() const { return fParticleSource.size(); }
 
     /// Returns the name of the particle source with index n (Geant4 based names).
-    TRestGeant4ParticleSource* GetParticleSource(int n) { return fParticleSource[n]; }
+    inline TRestGeant4ParticleSource* GetParticleSource(int n) { return fParticleSource[n]; }
 
     /// Remove all the particle sources.
     void RemoveParticleSources();
@@ -373,17 +365,17 @@ class TRestGeant4Metadata : public TRestMetadata {
     // Direct access to biasing volumes definition
     //////////////////////////////////////////////
     /// Returns the number of biasing volumes defined
-    Int_t GetNumberOfBiasingVolumes() { return fBiasingVolumes.size(); }
+    inline size_t GetNumberOfBiasingVolumes() const { return fBiasingVolumes.size(); }
 
     /// Return the biasing volume with index n
-    TRestGeant4BiasingVolume GetBiasingVolume(int n) { return fBiasingVolumes[n]; }
+    inline TRestGeant4BiasingVolume GetBiasingVolume(int n) { return fBiasingVolumes[n]; }
 
     /// \brief Returns the number of biasing volumes defined. If 0 the biasing technique
     /// is not being used.
     inline Int_t isBiasingActive() const { return fBiasingVolumes.size(); }
 
     /// Returns a std::string with the name of the sensitive volume.
-    TString GetSensitiveVolume() { return fSensitiveVolume; }
+    inline TString GetSensitiveVolume() const { return fSensitiveVolume; }
 
     /// Sets the name of the sensitive volume
     inline void SetSensitiveVolume(const TString& sensitiveVolume) { fSensitiveVolume = sensitiveVolume; }
@@ -423,7 +415,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     void PrintMetadata();
 
     TRestGeant4Metadata();
-    TRestGeant4Metadata(char* cfgFileName, std::string name = "");
+    TRestGeant4Metadata(const char* cfgFileName, const std::string& name = "");
 
     ~TRestGeant4Metadata();
 

--- a/src/TRestGeant4GeometryInfo.cxx
+++ b/src/TRestGeant4GeometryInfo.cxx
@@ -34,21 +34,26 @@ TString GetNodeAttribute(TXMLEngine xml, XMLNodePointer_t node, const TString& a
     }
     return {};
 }
-void AddVolumesRecursively(vector<TString>* container, const vector<TString>& children,
-                           map<TString, TString>& nameTable, map<TString, vector<TString>>& childrenTable,
-                           const TString& name = "") {
-    // cout << "called AddVolumesRecursively with name: " << name << endl;
+void AddVolumesRecursively(vector<TString>* physicalNames, vector<TString>* logicalNames,
+                           const vector<TString>& children, map<TString, TString>& nameTable,
+                           map<TString, vector<TString>>& childrenTable, const TString& name = "") {
+    /*
+    cout << "called AddVolumesRecursively with name: " << name << endl;
     for (const auto& child : children) {
-        // cout << "\t" << child << endl;
+        cout << "\t" << child << endl;
     }
+     */
     if (children.empty()) {
-        container->push_back(name);
-        // cout << "ADDED: " << name << endl;
+        physicalNames->push_back(name);
+        const auto logicalVolumeName = nameTable[name];
+        logicalNames->push_back(logicalVolumeName);
         return;
     }
     for (const auto& childName : children) {
-        AddVolumesRecursively(container, childrenTable[nameTable[childName]], nameTable, childrenTable,
-                              name + "_" + childName);
+        const auto newName = name + "_" + childName;
+        nameTable[newName] = nameTable[childName];  // needed to retrieve logical volume name
+        AddVolumesRecursively(physicalNames, logicalNames, childrenTable[nameTable[childName]], nameTable,
+                              childrenTable, newName);
     }
 }
 }  // namespace myXml
@@ -103,9 +108,11 @@ void TRestGeant4GeometryInfo::PopulateFromGdml(const TString& gdmlFilename) {
     }
 
     fGdmlNewPhysicalNames.clear();
+    fGdmlLogicalNames.clear();
     for (const auto& topName : childrenTable[worldVolumeName]) {
         auto children = childrenTable[nameTable[topName]];
-        myXml::AddVolumesRecursively(&fGdmlNewPhysicalNames, children, nameTable, childrenTable, topName);
+        myXml::AddVolumesRecursively(&fGdmlNewPhysicalNames, &fGdmlLogicalNames, children, nameTable,
+                                     childrenTable, topName);
     }
 
     xml.FreeDoc(xmldoc);

--- a/src/TRestGeant4GeometryInfo.cxx
+++ b/src/TRestGeant4GeometryInfo.cxx
@@ -37,13 +37,13 @@ TString GetNodeAttribute(TXMLEngine xml, XMLNodePointer_t node, const TString& a
 void AddVolumesRecursively(vector<TString>* container, const vector<TString>& children,
                            map<TString, TString>& nameTable, map<TString, vector<TString>>& childrenTable,
                            const TString& name = "") {
-    // G4cout << "called AddVolumesRecursively with name: " << name << endl;
+    // cout << "called AddVolumesRecursively with name: " << name << endl;
     for (const auto& child : children) {
-        // G4cout << "\t" << child << endl;
+        // cout << "\t" << child << endl;
     }
     if (children.empty()) {
         container->push_back(name);
-        // G4cout << "ADDED: " << name << endl;
+        // cout << "ADDED: " << name << endl;
         return;
     }
     for (const auto& childName : children) {
@@ -54,6 +54,9 @@ void AddVolumesRecursively(vector<TString>* container, const vector<TString>& ch
 }  // namespace myXml
 
 void TRestGeant4GeometryInfo::PopulateFromGdml(const TString& gdmlFilename) {
+    /*
+     * Fills 'fGdmlNewPhysicalNames' with physical volume names generated from GDML
+     */
     cout << "TRestGeant4GeometryInfo::PopulateFromGdml - " << gdmlFilename << endl;
     // Geometry must be in GDML
     TXMLEngine xml;

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1069,9 +1069,9 @@ void TRestGeant4Metadata::ReadStorage() {
                 if (fGeant4GeometryInfo.fGdmlLogicalNames[i] == name) {
                     isValidLogical = true;
                     const auto& gdmlName = fGeant4GeometryInfo.fGdmlNewPhysicalNames[i];
-                    SetActiveVolume(gdmlName, chance, maxStep);
                     info << "Adding active volume from RML: '" << gdmlName << "' from logical volume: '"
                          << name << "' with chance: " << chance << endl;
+                    SetActiveVolume(gdmlName, chance, maxStep);
                 }
             }
             if (!isValidLogical) {
@@ -1080,8 +1080,8 @@ void TRestGeant4Metadata::ReadStorage() {
                 exit(1);
             }
         } else {
-            SetActiveVolume(name, chance, maxStep);
             info << "Adding active volume from RML: '" << name << "' with chance: " << chance << endl;
+            SetActiveVolume(name, chance, maxStep);
         }
         volumeDefinition = GetNextElement(volumeDefinition);
     }
@@ -1503,7 +1503,15 @@ Int_t TRestGeant4Metadata::GetActiveVolumeID(TString name) {
 /// The aim of this parameter is to define control volumes. Usually the volume
 /// of interest will be always registered (chance=1).
 ///
-void TRestGeant4Metadata::SetActiveVolume(TString name, Double_t chance, Double_t maxStep) {
+void TRestGeant4Metadata::SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep) {
+    for (size_t i = 0; i < fActiveVolumes.size(); i++) {
+        const auto activeVolumeName = fActiveVolumes[i];
+        if (name == activeVolumeName) {
+            fChance[i] = chance;
+            fMaxStepSize[i] = maxStep;
+            return;
+        }
+    }
     fActiveVolumes.push_back(name);
     fChance.push_back(chance);
     fMaxStepSize.push_back(maxStep);

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -139,7 +139,7 @@
 /// parameters.
 ///
 /// \code
-///		<parameter name="Nevents" value="100" />
+///		<parameter name="nEvents" value="100" />
 ///		<parameter name="gdml_file" value="/path/to/mySetupTemplate.gdml"/>
 ///		<parameter name="maxTargetStepSize" value="200" units="um" />
 ///		<parameter name="subEventTimeDelay" value="100" units="us" />
@@ -756,17 +756,16 @@ void TRestGeant4Metadata::InitFromConfigFile() {
 
     // Initialize the metadata members from a configfile
     fGdmlFilename = GetParameter("gdml_file");
-
     fGeometryPath = GetParameter("geometryPath", "");
 
-    string seedstr = GetParameter("seed", "0");
-    if (ToUpper(seedstr) == "RANDOM" || ToUpper(seedstr) == "RAND" || ToUpper(seedstr) == "AUTO" ||
-        seedstr == "0") {
-        double* dd = new double();
+    string seedString = GetParameter("seed", "0");
+    if (ToUpper(seedString) == "RANDOM" || ToUpper(seedString) == "RAND" || ToUpper(seedString) == "AUTO" ||
+        seedString == "0") {
+        auto dd = new double();
         fSeed = (uintptr_t)dd + (uintptr_t)this;
         delete dd;
     } else {
-        fSeed = (Long_t)StringToInteger(seedstr);
+        fSeed = (Long_t)StringToInteger(seedString);
     }
     gRandom->SetSeed(fSeed);
 
@@ -784,7 +783,15 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     Double_t defaultTime = 1. / REST_Units::s;
     fSubEventTimeDelay = GetDblParameterWithUnits("subEventTimeDelay", defaultTime);
 
-    fNEvents = StringToInteger(GetParameter("Nevents"));
+    auto nEventsString = GetParameter("nEvents");
+    if (nEventsString == PARAMETER_NOT_FOUND_STR) {
+        nEventsString = GetParameter("Nevents");  // old name
+    }
+    if (nEventsString == PARAMETER_NOT_FOUND_STR) {
+        cout << "\"nEvents\" parameter is not defined!" << endl;
+        exit(1);
+    }
+    fNEvents = StringToInteger(nEventsString);
 
     fSaveAllEvents = ToUpper(GetParameter("saveAllEvents", "false")) == "TRUE" ||
                      ToUpper(GetParameter("saveAllEvents", "off")) == "ON";

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1064,13 +1064,17 @@ void TRestGeant4Metadata::ReadStorage() {
         const TString& name = GetFieldValue("name", volumeDefinition);
         // first we verify it's in the list of valid volumes
         if (!fGeant4GeometryInfo.IsValidGdmlName(name)) {
-            if (fGeant4GeometryInfo.IsValidLogicalVolume(name)) {
-                for (const auto& gdmlName : fGeant4GeometryInfo.GetAllPhysicalVolumesFromLogical(name)) {
+            bool isValidLogical = false;
+            for (size_t i = 0; i < fGeant4GeometryInfo.fGdmlNewPhysicalNames.size(); i++) {
+                if (fGeant4GeometryInfo.fGdmlLogicalNames[i] == name) {
+                    isValidLogical = true;
+                    const auto& gdmlName = fGeant4GeometryInfo.fGdmlNewPhysicalNames[i];
                     SetActiveVolume(gdmlName, chance, maxStep);
-                    info << "Adding active volume from RML: '" << gdmlName << "' with chance: " << chance
-                         << endl;
+                    info << "Adding active volume from RML: '" << gdmlName << "' from logical volume: '"
+                         << name << "' with chance: " << chance << endl;
                 }
-            } else {
+            }
+            if (!isValidLogical) {
                 ferr << "TRestGeant4Metadata: Problem reading storage section." << endl;
                 ferr << " 	- The volume '" << name << "' was not found in the GDML geometry." << endl;
                 exit(1);

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -210,32 +210,32 @@
 ///     <generator type="volume" from="vessel" > ... </generator>
 /// \endcode
 ///
-/// * **box**: Bound the generator to a virtual box area. "position" defines the centor of the
-/// box, while the three elements of "size" defines respectivally x, y, z length of the box.
+/// * **box**: Bound the generator to a virtual box area. "position" defines the center of the
+/// box, while the three elements of "size" defines respectively x, y, z length of the box.
 ///  \code
 ///     <generator type="volume" shape="box" size="(10,20,20)" position="(0,0,5)" > ... </generator>
 /// \endcode
 ///
 /// * **cylinder**: Bound the generator to a virtual cylinder area. "position" defines the
-/// centor of the cylinder, while the three elements of "size" defines respectivally
+/// center of the cylinder, while the three elements of "size" defines respectively
 /// radius, length, nothing of the cylinder.
 ///
 /// * **sphere**: Bound the generator to a virtual sphere area. "position" defines the
-/// centor of the sphere, while the three elements of "size" defines respectivally
+/// center of the sphere, while the three elements of "size" defines respectively
 /// radius, nothing, nothing of the sphere. In future we may implement ellipsoid
 /// support for the sphere and uses all three elements.
 ///
-/// * **plate**: Bound the generator to a virtual plate area. "position" defines the
-/// centor of the plate, while the three elements of "size" defines respectivally
-/// radius, nothing, nothing of the plate. "plate" shape works only for "surface"
-/// generator type. The initial direction of the plate is in parallel to x-y plane.
+/// * **circle**: Bound the generator to a virtual circle area. "position" defines the
+/// center of the circle, while the three elements of "size" defines respectively
+/// radius, nothing, nothing of the circle. "circle" shape works only for "surface"
+/// generator type. The initial direction of the circle is in parallel to x-y plane.
 /// \code
-///     // We launch particles from random positions on a virtual plate
-///     <generator type="surface" shape="plate" size="(10,0,0)" position="(0,0,0)" > ... </generator>
+///     // We launch particles from random positions on a virtual circle
+///     <generator type="surface" shape="circle" size="(10,0,0)" position="(0,0,0)" > ... </generator>
 /// \endcode
 ///
 /// * **wall**: Bound the generator to a virtual rectangle area. "position" defines the
-/// centor of the rectangle, while the three elements of "size" defines respectivally
+/// center of the rectangle, while the three elements of "size" defines respectively
 /// x, y, nothing length the rectangle. "rectangle" shape works only for "surface"
 /// generator type. The initial direction of the rectangle is in parallel to x-y plane.
 ///
@@ -254,8 +254,8 @@
 /// the surface. We can define additional density function to customize the particle
 /// origin distribution. The function is a TF3 function with x, y, z the absolute
 /// position(position of gdml frame instead of generator frame) of the particle in
-/// unit mm. The returned value should be in range 0-1, indicating the relative probablity
-/// in this position. For example, we simulate some radio isotopes plated on a chip
+/// unit mm. The returned value should be in range 0-1, indicating the relative probability
+/// in this position. For example, we simulate some radio isotopes placed on a chip
 /// with doping which follows exponential density distribution near the surface:
 /// \code
 ///     <generator type="volume" shape="box" size="(10,10,1)mm" position="(0,0,0.5)"
@@ -645,12 +645,14 @@
 ///
 /// <hr>
 ///
+
 #include "TRestGeant4Metadata.h"
+
 using namespace std;
 
 #include <TGeoManager.h>
+#include <TRandom.h>
 
-#include "TRandom.h"
 #include "TRestGDMLParser.h"
 
 namespace g4_metadata_parameters {
@@ -673,7 +675,7 @@ map<string, generator_types> generator_types_map = {
 
 std::map<string, generator_shapes> generator_shapes_map = {
     {CleanString("gdml"), generator_shapes::GDML},     {CleanString("wall"), generator_shapes::WALL},
-    {CleanString("plate"), generator_shapes::PLATE},   {CleanString("box"), generator_shapes::BOX},
+    {CleanString("circle"), generator_shapes::CIRCLE}, {CleanString("box"), generator_shapes::BOX},
     {CleanString("sphere"), generator_shapes::SPHERE}, {CleanString("cylinder"), generator_shapes::CYLINDER},
 };
 
@@ -1145,7 +1147,7 @@ void TRestGeant4Metadata::PrintMetadata() {
             metadata << ", (radius, , ): ";
         } else if (fGenShape == "wall") {
             metadata << ", (length, width, ): ";
-        } else if (fGenShape == "plate") {
+        } else if (fGenShape == "circle") {
             metadata << ", (radius, , ): ";
         } else if (fGenShape == "cylinder") {
             metadata << ", (radius, length, ): ";

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -715,7 +715,8 @@ TRestGeant4Metadata::TRestGeant4Metadata() : TRestMetadata() { Initialize(); }
 /// \param name The name of the specific metadata. It will be used to find the
 /// corresponding TRestGeant4Metadata section inside the RML.
 ///
-TRestGeant4Metadata::TRestGeant4Metadata(char* cfgFileName, string name) : TRestMetadata(cfgFileName) {
+TRestGeant4Metadata::TRestGeant4Metadata(const char* cfgFileName, const string& name)
+    : TRestMetadata(cfgFileName) {
     Initialize();
 
     LoadConfigFromFile(fConfigFileName, name);

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -114,7 +114,7 @@
 /// different isotope decays are stored in different events.
 ///
 /// [GDML]: https://gdml.web.cern.ch/GDML/
-/// * **gdml_file**: The path and name of the main GDML file. Both relative and
+/// * **gdmlFile**: The path and name of the main GDML file. Both relative and
 /// absolute path is supported. In principle, the
 /// user has full freedom to create any detector setup geometry using a
 /// [GDML][GDML] description.
@@ -140,7 +140,7 @@
 ///
 /// \code
 ///		<parameter name="nEvents" value="100" />
-///		<parameter name="gdml_file" value="/path/to/mySetupTemplate.gdml"/>
+///		<parameter name="gdmlFile" value="/path/to/mySetupTemplate.gdml"/>
 ///		<parameter name="maxTargetStepSize" value="200" units="um" />
 ///		<parameter name="subEventTimeDelay" value="100" units="us" />
 /// \endcode
@@ -755,7 +755,15 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     fMagneticField = Get3DVectorParameterWithUnits("magneticField", TVector3(0, 0, 0));
 
     // Initialize the metadata members from a configfile
-    fGdmlFilename = GetParameter("gdml_file");
+    fGdmlFilename = GetParameter("gdmlFile");
+    if (fGdmlFilename == PARAMETER_NOT_FOUND_STR) {
+        fGdmlFilename = GetParameter("gdml_file");  // old name
+    }
+    if (fGdmlFilename == PARAMETER_NOT_FOUND_STR) {
+        cout << "\"gdmlFile\" parameter is not defined!" << endl;
+        exit(1);
+    }
+
     fGeometryPath = GetParameter("geometryPath", "");
 
     string seedString = GetParameter("seed", "0");
@@ -769,14 +777,14 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     }
     gRandom->SetSeed(fSeed);
 
-    // if "gdml_file" is purely a file (without any path) and "geometryPath" is
+    // if "gdmlFile" is purely a file (without any path) and "geometryPath" is
     // defined, we recombine them together
     if ((((string)fGdmlFilename).find_first_not_of("./~") == 0 || ((string)fGdmlFilename).find("/") == -1) &&
         fGeometryPath != "") {
         if (fGeometryPath[fGeometryPath.Length() - 1] == '/') {
-            fGdmlFilename = fGeometryPath + GetParameter("gdml_file");
+            fGdmlFilename = fGeometryPath + GetParameter("gdmlFile");
         } else {
-            fGdmlFilename = fGeometryPath + "/" + GetParameter("gdml_file");
+            fGdmlFilename = fGeometryPath + "/" + GetParameter("gdmlFile");
         }
     }
 

--- a/test/files/TRestGeant4Example.rml
+++ b/test/files/TRestGeant4Example.rml
@@ -4,7 +4,7 @@
 
     <TRestGeant4Metadata name="Test Simulation" title="Test Simulation Title">
 
-        <parameter name="gdml_file" value="this-geometry-does-not-exist.gdml"/>
+        <parameter name="gdmlFile" value="this-geometry-does-not-exist.gdml"/>
         <parameter name="subEventTimeDelay" value="100" units="us"/>
         <parameter name="seed" value="17021981"/>
         <parameter name="nEvents" value="1"/>

--- a/test/files/TRestGeant4Example.rml
+++ b/test/files/TRestGeant4Example.rml
@@ -7,7 +7,7 @@
         <parameter name="gdml_file" value="this-geometry-does-not-exist.gdml"/>
         <parameter name="subEventTimeDelay" value="100" units="us"/>
         <parameter name="seed" value="17021981"/>
-        <parameter name="Nevents" value="1"/>
+        <parameter name="nEvents" value="1"/>
 
         <generator type="point" position="(0, 0, 0)">
             <source particle="geantino">

--- a/test/src/TRestGeant4Metadata.cxx
+++ b/test/src/TRestGeant4Metadata.cxx
@@ -8,19 +8,19 @@ namespace fs = std::filesystem;
 
 using namespace std;
 
-#define FILES_PATH fs::path(__FILE__).parent_path().parent_path() / "files"
-#define GEANT4_METADATA_RML FILES_PATH / "TRestGeant4Example.rml"
+const auto filesPath = fs::path(__FILE__).parent_path().parent_path() / "files";
+const auto geant4MetadataRml = filesPath / "TRestGeant4Example.rml";
 
 TEST(TRestGeant4Metadata, TestFiles) {
-    cout << "FrameworkCore test files path: " << FILES_PATH << endl;
+    cout << "FrameworkCore test files path: " << filesPath << endl;
 
     // Check dir exists and is a directory
-    EXPECT_TRUE(fs::is_directory(FILES_PATH));
+    EXPECT_TRUE(fs::is_directory(filesPath));
     // Check it's not empty
-    EXPECT_TRUE(!fs::is_empty(FILES_PATH));
+    EXPECT_TRUE(!fs::is_empty(filesPath));
 
     // All used files in this tests
-    EXPECT_TRUE(fs::exists(GEANT4_METADATA_RML));
+    EXPECT_TRUE(fs::exists(geant4MetadataRml));
 }
 
 TEST(TRestGeant4Metadata, Default) {
@@ -33,13 +33,11 @@ TEST(TRestGeant4Metadata, Default) {
 }
 
 TEST(TRestGeant4Metadata, FromRml) {
-    const auto metadataConfigRml = GEANT4_METADATA_RML;
+    GTEST_SKIP_("Problem with paths...");
 
-    TRestGeant4Metadata restGeant4Metadata((char*)metadataConfigRml.c_str());
+    TRestGeant4Metadata restGeant4Metadata(geant4MetadataRml.c_str());
 
     restGeant4Metadata.PrintMetadata();
-
-    GTEST_SKIP_("If it doesn't find the gdml, test will always return OK for some reason. TODO: fix this");
 
     EXPECT_TRUE(restGeant4Metadata.GetSensitiveVolume() == "sensitiveVolume");
     EXPECT_TRUE(restGeant4Metadata.GetSeed() == 17021981);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 167](https://badgen.net/badge/PR%20Size/Medium%3A%20167/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-activeVolume-43/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-activeVolume-43) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-activeVolume-43/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-activeVolume-43) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-activeVolume-43/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-activeVolume-43)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Fixes https://github.com/rest-for-physics/restG4/issues/43
* Replaces `Nevents` by `nEvents` in RML files (`Nevents` still works) for consistency
* Replaces `gdml_file` by `gdmlFile` in RML files (`gdml_file` still works) for consistency
* Replaced "plate" by "circle" in generator, for consistency with Geant4 (also I don't think a plate is necessarily circular, its more like a "sheet")
* Other minor changes