### PR TITLE
Renaming endl to RESTendl and other loggers functions

### DIFF
--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -112,8 +112,8 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Low energy cut : " << fLowEnergyCut << " keV" << endl;
-        metadata << "High energy cut : " << fHighEnergyCut << " keV" << endl;
+        RESTMetadata << "Low energy cut : " << fLowEnergyCut << " keV" << RESTendl;
+        RESTMetadata << "High energy cut : " << fHighEnergyCut << " keV" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestGeant4NeutronTaggingProcess.h
+++ b/inc/TRestGeant4NeutronTaggingProcess.h
@@ -105,48 +105,48 @@ class TRestGeant4NeutronTaggingProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        debug << "VETO KEYWORD: " << fVetoKeyword << endl;
-        debug << endl;
+        RESTDebug << "VETO KEYWORD: " << fVetoKeyword << RESTendl;
+        RESTDebug << RESTendl;
 
-        debug << "VETO GROUP KEYWORDS:" << endl;
+        RESTDebug << "VETO GROUP KEYWORDS:" << RESTendl;
         for (unsigned int i = 0; i < fVetoGroupKeywords.size(); i++) {
-            debug << "\t" << fVetoGroupKeywords[i] << endl;
+            RESTDebug << "\t" << fVetoGroupKeywords[i] << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
-        debug << "Found " << fVetoVolumeIds.size() << " veto volumes:" << endl;
+        RESTDebug << "Found " << fVetoVolumeIds.size() << " veto volumes:" << RESTendl;
         for (unsigned int i = 0; i < fVetoVolumeIds.size(); i++) {
-            debug << "\t" << fG4Metadata->GetActiveVolumeName(fVetoVolumeIds[i]) << endl;
+            RESTDebug << "\t" << fG4Metadata->GetActiveVolumeName(fVetoVolumeIds[i]) << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
         // capture volumes
 
-        debug << "CAPTURE KEYWORD: " << fCaptureKeyword << endl;
-        debug << endl;
+        RESTDebug << "CAPTURE KEYWORD: " << fCaptureKeyword << RESTendl;
+        RESTDebug << RESTendl;
 
-        debug << "Found " << fCaptureVolumeIds.size() << " Capture volumes:" << endl;
+        RESTDebug << "Found " << fCaptureVolumeIds.size() << " Capture volumes:" << RESTendl;
         for (unsigned int i = 0; i < fCaptureVolumeIds.size(); i++) {
-            debug << "\t" << fG4Metadata->GetActiveVolumeName(fCaptureVolumeIds[i]) << endl;
+            RESTDebug << "\t" << fG4Metadata->GetActiveVolumeName(fCaptureVolumeIds[i]) << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
         // shielding volume/s
 
-        debug << "SHIELDING KEYWORD: " << fShieldingKeyword << endl;
-        debug << endl;
+        RESTDebug << "SHIELDING KEYWORD: " << fShieldingKeyword << RESTendl;
+        RESTDebug << RESTendl;
 
-        debug << "Found " << fShieldingVolumeIds.size() << " Shielding volumes:" << endl;
+        RESTDebug << "Found " << fShieldingVolumeIds.size() << " Shielding volumes:" << RESTendl;
         for (unsigned int i = 0; i < fShieldingVolumeIds.size(); i++) {
-            debug << "\t" << fG4Metadata->GetActiveVolumeName(fShieldingVolumeIds[i]) << endl;
+            RESTDebug << "\t" << fG4Metadata->GetActiveVolumeName(fShieldingVolumeIds[i]) << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
-        debug << "QUENCHING FACTORS (" << fQuenchingFactors.size() << " Total)" << endl;
+        RESTDebug << "QUENCHING FACTORS (" << fQuenchingFactors.size() << " Total)" << RESTendl;
         for (unsigned int i = 0; i < fQuenchingFactors.size(); i++) {
-            debug << "\t" << fQuenchingFactors[i] << endl;
+            RESTDebug << "\t" << fQuenchingFactors[i] << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -86,35 +86,35 @@ class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        debug << "VETO KEYWORD: " << fVetoKeyword << endl;
-        debug << endl;
+        RESTDebug << "VETO KEYWORD: " << fVetoKeyword << RESTendl;
+        RESTDebug << RESTendl;
 
-        debug << "VETO GROUP KEYWORDS:" << endl;
+        RESTDebug << "VETO GROUP KEYWORDS:" << RESTendl;
         for (unsigned int i = 0; i < fVetoGroupKeywords.size(); i++) {
-            debug << "\t" << fVetoGroupKeywords[i] << endl;
+            RESTDebug << "\t" << fVetoGroupKeywords[i] << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
-        debug << "Found " << fVetoVolumeIds.size() << " veto volumes:" << endl;
+        RESTDebug << "Found " << fVetoVolumeIds.size() << " veto volumes:" << RESTendl;
         for (unsigned int i = 0; i < fVetoVolumeIds.size(); i++) {
-            debug << "\t" << fG4Metadata->GetActiveVolumeName(fVetoVolumeIds[i]) << endl;
+            RESTDebug << "\t" << fG4Metadata->GetActiveVolumeName(fVetoVolumeIds[i]) << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
-        debug << "GROUPS:" << endl;
+        RESTDebug << "GROUPS:" << RESTendl;
         for (const auto& pair : fVetoGroupVolumeNames) {
-            debug << "GROUP " << pair.first << " (" << pair.second.size() << " volumes):\n";
+            RESTDebug << "GROUP " << pair.first << " (" << pair.second.size() << " volumes):\n";
             for (unsigned int i = 0; i < pair.second.size(); i++) {
-                debug << "\t" << pair.second[i] << endl;
+                RESTDebug << "\t" << pair.second[i] << RESTendl;
             }
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
-        debug << "QUENCHING FACTORS (" << fQuenchingFactors.size() << " Total)" << endl;
+        RESTDebug << "QUENCHING FACTORS (" << fQuenchingFactors.size() << " Total)" << RESTendl;
         for (unsigned int i = 0; i < fQuenchingFactors.size(); i++) {
-            debug << "\t" << fQuenchingFactors[i] << endl;
+            RESTDebug << "\t" << fQuenchingFactors[i] << RESTendl;
         }
-        debug << endl;
+        RESTDebug << RESTendl;
 
         EndPrintProcess();
     }

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -421,7 +421,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     Double_t energy = fOutputG4Event->GetSensitiveVolumeEnergy();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "----------------------------" << endl;
         cout << "TRestGeant4Event : " << fOutputG4Event->GetID() << endl;
         cout << "Sensitive volume Energy : " << energy << endl;
@@ -583,7 +583,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue((string)obsName, mpos);
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "G4 Tracks : " << fOutputG4Event->GetNumberOfTracks() << endl;
         cout << "----------------------------" << endl;
     }

--- a/src/TRestGeant4EventViewer.cxx
+++ b/src/TRestGeant4EventViewer.cxx
@@ -181,8 +181,8 @@ void TRestGeant4EventViewer::AddTrack(Int_t trkID, Int_t parentID, TVector3 from
     if (fHitConnectors.size() > parentID)
         fHitConnectors[parentID]->AddElement(fHitConnectors[trkID]);
     else {
-        warning << "Parent ID: " << parentID << " of track " << trkID << " was not found!" << endl;
-        warning << "This might be solved by enabling TRestGeant4Metadata::fRegisterEmptyTracks" << endl;
+        RESTWarning << "Parent ID: " << parentID << " of track " << trkID << " was not found!" << RESTendl;
+        RESTWarning << "This might be solved by enabling TRestGeant4Metadata::fRegisterEmptyTracks" << RESTendl;
     }
 }
 

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -963,7 +963,7 @@ void TRestGeant4Metadata::ReadGenerator() {
 
     // check if the generator is valid.
     if (GetNumberOfSources() == 0) {
-        RESTFerr << "No sources are added inside geneartor!" << RESTendl;
+        RESTError << "No sources are added inside geneartor!" << RESTendl;
         exit(1);
     }
 }
@@ -1093,8 +1093,8 @@ void TRestGeant4Metadata::ReadStorage() {
                 }
             }
             if (!isValidLogical) {
-                RESTFerr << "TRestGeant4Metadata: Problem reading storage section." << RESTendl;
-                RESTFerr << " 	- The volume '" << name << "' was not found in the GDML geometry." << RESTendl;
+                RESTError << "TRestGeant4Metadata: Problem reading storage section." << RESTendl;
+                RESTError << " 	- The volume '" << name << "' was not found in the GDML geometry." << RESTendl;
                 exit(1);
             }
         } else {

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -822,22 +822,22 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     fMaxTargetStepSize = GetDblParameterWithUnits("maxTargetStepSize", -1);
     if (fMaxTargetStepSize > 0) {
         cout << " " << endl;
-        warning << "IMPORTANT: *maxTargetStepSize* parameter is now obsolete!" << endl;
-        warning << "The sensitive volume will not define any integration step limit" << endl;
+        RESTWarning << "IMPORTANT: *maxTargetStepSize* parameter is now obsolete!" << RESTendl;
+        RESTWarning << "The sensitive volume will not define any integration step limit" << RESTendl;
         cout << " " << endl;
-        warning << "In order to avoid this warning REMOVE the *maxTargetStepSize* definition," << endl;
-        warning << "and replace it by the following statement at the <storage> section" << endl;
+        RESTWarning << "In order to avoid this warning REMOVE the *maxTargetStepSize* definition," << RESTendl;
+        RESTWarning << "and replace it by the following statement at the <storage> section" << RESTendl;
         cout << " " << endl;
-        warning << "<activeVolume name=\"" << this->GetSensitiveVolume() << "\" maxStepSize=\""
-                << fMaxTargetStepSize << "mm\" />" << endl;
+        RESTWarning << "<activeVolume name=\"" << this->GetSensitiveVolume() << "\" maxStepSize=\""
+                << fMaxTargetStepSize << "mm\" />" << RESTendl;
         cout << " " << endl;
-        info << "Now, any active volume is allowed to define a maxStepSize" << endl;
+        RESTInfo << "Now, any active volume is allowed to define a maxStepSize" << RESTendl;
         cout << " " << endl;
-        info << "It is also possible to define a default step size for all active volumes," << endl;
-        info << "so that in case no step is defined, the default will be used." << endl;
+        RESTInfo << "It is also possible to define a default step size for all active volumes," << RESTendl;
+        RESTInfo << "so that in case no step is defined, the default will be used." << RESTendl;
         cout << " " << endl;
-        info << "<storage sensitiveVolume=\"" << this->GetSensitiveVolume() << "\" maxStepSize=\""
-             << fMaxTargetStepSize << "mm\" />" << endl;
+        RESTInfo << "<storage sensitiveVolume=\"" << this->GetSensitiveVolume() << "\" maxStepSize=\""
+             << fMaxTargetStepSize << "mm\" />" << RESTendl;
         cout << " " << endl;
         GetChar();
     }
@@ -872,16 +872,16 @@ void TRestGeant4Metadata::ReadBiasing() {
     TString biasEnabled = GetFieldValue("value", biasingDefinition);
     TString biasType = GetFieldValue("type", biasingDefinition);
 
-    debug << "Bias : " << biasEnabled << endl;
+    RESTDebug << "Bias : " << biasEnabled << RESTendl;
 
     if (biasEnabled == "on" || biasEnabled == "ON" || biasEnabled == "On" || biasEnabled == "oN") {
-        info << "Biasing is enabled" << endl;
+        RESTInfo << "Biasing is enabled" << RESTendl;
 
         TiXmlElement* biasVolumeDefinition = GetElement("biasingVolume", biasingDefinition);
         Int_t n = 0;
         while (biasVolumeDefinition) {
             TRestGeant4BiasingVolume biasVolume;
-            debug << "Def : " << biasVolumeDefinition << endl;
+            RESTDebug << "Def : " << biasVolumeDefinition << RESTendl;
 
             biasVolume.SetBiasingVolumePosition(
                 Get3DVectorParameterWithUnits("position", biasVolumeDefinition));
@@ -963,7 +963,7 @@ void TRestGeant4Metadata::ReadGenerator() {
 
     // check if the generator is valid.
     if (GetNumberOfSources() == 0) {
-        ferr << "No sources are added inside geneartor!" << endl;
+        RESTFerr << "No sources are added inside geneartor!" << RESTendl;
         exit(1);
     }
 }
@@ -1055,13 +1055,13 @@ void TRestGeant4Metadata::ReadStorage() {
     TiXmlElement* storageDefinition = GetElement("storage");
     fSensitiveVolume = GetFieldValue("sensitiveVolume", storageDefinition);
     if (fSensitiveVolume == "Not defined") {
-        warning << "Sensitive volume not defined. Setting it to 'gas'!" << endl;
+        RESTWarning << "Sensitive volume not defined. Setting it to 'gas'!" << RESTendl;
         fSensitiveVolume = "gas";
     }
     Double_t defaultStep = GetDblParameterWithUnits("maxStepSize", storageDefinition);
     if (defaultStep < 0) defaultStep = 0;
 
-    info << "Sensitive volume: " << fSensitiveVolume << endl;
+    RESTInfo << "Sensitive volume: " << fSensitiveVolume << RESTendl;
 
     fEnergyRangeStored = Get2DVectorParameterWithUnits("energyRange", storageDefinition);
 
@@ -1087,18 +1087,18 @@ void TRestGeant4Metadata::ReadStorage() {
                 if (fGeant4GeometryInfo.fGdmlLogicalNames[i] == name) {
                     isValidLogical = true;
                     const auto& gdmlName = fGeant4GeometryInfo.fGdmlNewPhysicalNames[i];
-                    info << "Adding active volume from RML: '" << gdmlName << "' from logical volume: '"
-                         << name << "' with chance: " << chance << endl;
+                    RESTInfo << "Adding active volume from RML: '" << gdmlName << "' from logical volume: '"
+                         << name << "' with chance: " << chance << RESTendl;
                     SetActiveVolume(gdmlName, chance, maxStep);
                 }
             }
             if (!isValidLogical) {
-                ferr << "TRestGeant4Metadata: Problem reading storage section." << endl;
-                ferr << " 	- The volume '" << name << "' was not found in the GDML geometry." << endl;
+                RESTFerr << "TRestGeant4Metadata: Problem reading storage section." << RESTendl;
+                RESTFerr << " 	- The volume '" << name << "' was not found in the GDML geometry." << RESTendl;
                 exit(1);
             }
         } else {
-            info << "Adding active volume from RML: '" << name << "' with chance: " << chance << endl;
+            RESTInfo << "Adding active volume from RML: '" << name << "' with chance: " << chance << RESTendl;
             SetActiveVolume(name, chance, maxStep);
         }
         volumeDefinition = GetNextElement(volumeDefinition);
@@ -1109,7 +1109,7 @@ void TRestGeant4Metadata::ReadStorage() {
     if (GetNumberOfActiveVolumes() == 0) {
         for (auto& name : physicalVolumes) {
             SetActiveVolume(name, 1, defaultStep);
-            info << "Automatically adding active volume: '" << name << "' with chance: " << 1 << endl;
+            RESTInfo << "Automatically adding active volume: '" << name << "' with chance: " << 1 << RESTendl;
         }
     }
 }
@@ -1121,70 +1121,70 @@ void TRestGeant4Metadata::ReadStorage() {
 void TRestGeant4Metadata::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
-    metadata << "Geant 4 version : " << GetGeant4Version() << endl;
-    metadata << "Random seed : " << GetSeed() << endl;
-    metadata << "GDML geometry : " << GetGdmlReference() << endl;
-    metadata << "GDML materials reference : " << GetMaterialsReference() << endl;
-    metadata << "Sub-event time delay : " << GetSubEventTimeDelay() << " us" << endl;
+    RESTMetadata << "Geant 4 version : " << GetGeant4Version() << RESTendl;
+    RESTMetadata << "Random seed : " << GetSeed() << RESTendl;
+    RESTMetadata << "GDML geometry : " << GetGdmlReference() << RESTendl;
+    RESTMetadata << "GDML materials reference : " << GetMaterialsReference() << RESTendl;
+    RESTMetadata << "Sub-event time delay : " << GetSubEventTimeDelay() << " us" << RESTendl;
     Double_t mx = GetMagneticField().X();
     Double_t my = GetMagneticField().Y();
     Double_t mz = GetMagneticField().Z();
-    metadata << "Magnetic field : ( " << mx << ", " << my << ", " << mz << ") T" << endl;
-    if (fSaveAllEvents) metadata << "Save all events was enabled!" << endl;
+    RESTMetadata << "Magnetic field : ( " << mx << ", " << my << ", " << mz << ") T" << RESTendl;
+    if (fSaveAllEvents) RESTMetadata << "Save all events was enabled!" << RESTendl;
     if (fRegisterEmptyTracks)
-        metadata << "Register empty tracks was enabled" << endl;
+        RESTMetadata << "Register empty tracks was enabled" << RESTendl;
     else
-        metadata << "Register empty tracks was NOT enabled" << endl;
-    metadata << "   ++++++++++ Generator +++++++++++   " << endl;
-    metadata << "Number of generated events : " << GetNumberOfEvents() << endl;
-    metadata << "Generator type : " << fGenType << endl;
-    metadata << "Generator shape : " << fGenShape;
+        RESTMetadata << "Register empty tracks was NOT enabled" << RESTendl;
+    RESTMetadata << "   ++++++++++ Generator +++++++++++   " << RESTendl;
+    RESTMetadata << "Number of generated events : " << GetNumberOfEvents() << RESTendl;
+    RESTMetadata << "Generator type : " << fGenType << RESTendl;
+    RESTMetadata << "Generator shape : " << fGenShape;
     if (fGenShape == "gdml") {
-        metadata << "::" << GetGDMLGeneratorVolume() << endl;
+        RESTMetadata << "::" << GetGDMLGeneratorVolume() << RESTendl;
     } else {
         if (fGenShape == "box") {
-            metadata << ", (length, width, height): ";
+            RESTMetadata << ", (length, width, height): ";
         } else if (fGenShape == "sphere") {
-            metadata << ", (radius, , ): ";
+            RESTMetadata << ", (radius, , ): ";
         } else if (fGenShape == "wall") {
-            metadata << ", (length, width, ): ";
+            RESTMetadata << ", (length, width, ): ";
         } else if (fGenShape == "circle") {
-            metadata << ", (radius, , ): ";
+            RESTMetadata << ", (radius, , ): ";
         } else if (fGenShape == "cylinder") {
-            metadata << ", (radius, length, ): ";
+            RESTMetadata << ", (radius, length, ): ";
         }
 
         if (fGenShape != "point") {
             TVector3 s = GetGeneratorSize();
-            metadata << s.X() << ", " << s.Y() << ", " << s.Z() << endl;
+            RESTMetadata << s.X() << ", " << s.Y() << ", " << s.Z() << RESTendl;
         } else {
-            metadata << endl;
+            RESTMetadata << RESTendl;
         }
     }
     TVector3 a = GetGeneratorPosition();
-    metadata << "Generator center : (" << a.X() << "," << a.Y() << "," << a.Z() << ") mm" << endl;
+    RESTMetadata << "Generator center : (" << a.X() << "," << a.Y() << "," << a.Z() << ") mm" << RESTendl;
     TVector3 b = GetGeneratorRotationAxis();
-    metadata << "Generator rotation : (" << b.X() << "," << b.Y() << "," << b.Z()
-             << "), angle: " << GetGeneratorRotationDegree() << " rads" << endl;
+    RESTMetadata << "Generator rotation : (" << b.X() << "," << b.Y() << "," << b.Z()
+             << "), angle: " << GetGeneratorRotationDegree() << " rads" << RESTendl;
 
     for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();
 
-    metadata << "   ++++++++++ Storage volumes +++++++++++   " << endl;
-    metadata << "Energy range : Emin = " << GetMinimumEnergyStored()
-             << ", Emax : " << GetMaximumEnergyStored() << endl;
-    metadata << "Sensitive volume : " << GetSensitiveVolume() << endl;
-    metadata << "Active volumes : " << GetNumberOfActiveVolumes() << endl;
-    metadata << "---------------------------------------" << endl;
+    RESTMetadata << "   ++++++++++ Storage volumes +++++++++++   " << RESTendl;
+    RESTMetadata << "Energy range : Emin = " << GetMinimumEnergyStored()
+             << ", Emax : " << GetMaximumEnergyStored() << RESTendl;
+    RESTMetadata << "Sensitive volume : " << GetSensitiveVolume() << RESTendl;
+    RESTMetadata << "Active volumes : " << GetNumberOfActiveVolumes() << RESTendl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
     for (int n = 0; n < GetNumberOfActiveVolumes(); n++) {
-        metadata << "Name : " << GetActiveVolumeName(n)
+        RESTMetadata << "Name : " << GetActiveVolumeName(n)
                  << ", ID : " << GetActiveVolumeID(GetActiveVolumeName(n))
                  << ", maxStep : " << GetMaxStepSize(GetActiveVolumeName(n)) << "mm "
-                 << ", chance : " << GetStorageChance(GetActiveVolumeName(n)) << endl;
+                 << ", chance : " << GetStorageChance(GetActiveVolumeName(n)) << RESTendl;
     }
     for (int n = 0; n < GetNumberOfBiasingVolumes(); n++) {
         GetBiasingVolume(n).PrintBiasingVolume();
     }
-    metadata << "+++++" << endl;
+    RESTMetadata << "+++++" << RESTendl;
 }
 
 /////////////////////////////////////////////////
@@ -1554,7 +1554,7 @@ Double_t TRestGeant4Metadata::GetStorageChance(TString vol) {
     for (id = 0; id < (Int_t)fActiveVolumes.size(); id++) {
         if (fActiveVolumes[id] == vol) return fChance[id];
     }
-    warning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << endl;
+    RESTWarning << "TRestGeant4Metadata::GetStorageChance. Volume " << vol << " not found" << RESTendl;
 
     return 0;
 }
@@ -1566,7 +1566,7 @@ Double_t TRestGeant4Metadata::GetMaxStepSize(TString vol) {
     for (Int_t id = 0; id < (Int_t)fActiveVolumes.size(); id++) {
         if (fActiveVolumes[id] == vol) return fMaxStepSize[id];
     }
-    warning << "TRestGeant4Metadata::GetMaxStepSize. Volume " << vol << " not found" << endl;
+    RESTWarning << "TRestGeant4Metadata::GetMaxStepSize. Volume " << vol << " not found" << RESTendl;
 
     return 0;
 }

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -45,34 +45,34 @@ TRestGeant4ParticleSource::~TRestGeant4ParticleSource() {
 }
 
 void TRestGeant4ParticleSource::PrintParticleSource() {
-    metadata << "---------------------------------------" << endl;
-    metadata << "Particle Source Name: " << GetParticleName() << endl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
+    RESTMetadata << "Particle Source Name: " << GetParticleName() << RESTendl;
     if (fParticlesTemplate.size() > 0 || fGenFilename != "NO_SUCH_PARA") {
-        metadata << "Generator file: " << GetGenFilename() << endl;
-        metadata << "Stored templates: " << fParticlesTemplate.size() << endl;
-        metadata << "Particles: ";
-        for (auto p : fParticles) metadata << p.GetParticleName() << ", ";
-        metadata << endl;
+        RESTMetadata << "Generator file: " << GetGenFilename() << RESTendl;
+        RESTMetadata << "Stored templates: " << fParticlesTemplate.size() << RESTendl;
+        RESTMetadata << "Particles: ";
+        for (auto p : fParticles) RESTMetadata << p.GetParticleName() << ", ";
+        RESTMetadata << RESTendl;
     } else {
-        metadata << "Charge : " << GetParticleCharge() << endl;
-        metadata << "Angular distribution type : " << GetAngularDistType() << endl;
+        RESTMetadata << "Charge : " << GetParticleCharge() << RESTendl;
+        RESTMetadata << "Angular distribution type : " << GetAngularDistType() << RESTendl;
         if (GetAngularDistType() == "TH1D") {
-            metadata << "Angular distribution filename : "
-                     << TRestTools::GetPureFileName((string)GetAngularFilename()) << endl;
-            metadata << "Angular histogram name  : " << GetAngularName() << endl;
+            RESTMetadata << "Angular distribution filename : "
+                     << TRestTools::GetPureFileName((string)GetAngularFilename()) << RESTendl;
+            RESTMetadata << "Angular histogram name  : " << GetAngularName() << RESTendl;
         }
-        metadata << "Direction : (" << GetDirection().X() << "," << GetDirection().Y() << ","
-                 << GetDirection().Z() << ")" << endl;
-        metadata << "Energy distribution : " << GetEnergyDistType() << endl;
+        RESTMetadata << "Direction : (" << GetDirection().X() << "," << GetDirection().Y() << ","
+                 << GetDirection().Z() << ")" << RESTendl;
+        RESTMetadata << "Energy distribution : " << GetEnergyDistType() << RESTendl;
         if (GetEnergyDistType() == "TH1D") {
-            metadata << "Energy distribution filename : "
-                     << TRestTools::GetPureFileName((string)GetSpectrumFilename()) << endl;
-            metadata << "Energy histogram name  : " << GetSpectrumName() << endl;
+            RESTMetadata << "Energy distribution filename : "
+                     << TRestTools::GetPureFileName((string)GetSpectrumFilename()) << RESTendl;
+            RESTMetadata << "Energy histogram name  : " << GetSpectrumName() << RESTendl;
         } else if (GetEnergyRange().X() == GetEnergyRange().Y())
-            metadata << "Energy : " << GetEnergy() << " keV" << endl;
+            RESTMetadata << "Energy : " << GetEnergy() << " keV" << RESTendl;
         else
-            metadata << "Energy range : (" << GetEnergyRange().X() << "," << GetEnergyRange().Y() << ") keV"
-                     << endl;
+            RESTMetadata << "Energy range : (" << GetEnergyRange().X() << "," << GetEnergyRange().Y() << ") keV"
+                     << RESTendl;
     }
 }
 
@@ -103,8 +103,8 @@ void TRestGeant4ParticleSource::InitFromConfigFile() {
     if (((string)modelUse).find(".dat") != -1) {
         string fullPathName = SearchFile((string)modelUse);
         if (fullPathName == "") {
-            ferr << "File not found : " << modelUse << endl;
-            ferr << "Decay0 generator file could not be found!!" << endl;
+            RESTFerr << "File not found : " << modelUse << RESTendl;
+            RESTFerr << "Decay0 generator file could not be found!!" << RESTendl;
             exit(1);
         }
         modelUse = fullPathName;
@@ -178,7 +178,7 @@ bool TRestGeant4ParticleSource::ReadNewDecay0File(TString fileName) {
     }
 
     if (generatorEvents == 0) {
-        ferr << "TRestG4Metadata::ReadNewDecay0File. Problem reading generator file" << endl;
+        RESTFerr << "TRestG4Metadata::ReadNewDecay0File. Problem reading generator file" << RESTendl;
         exit(1);
     }
 
@@ -189,8 +189,8 @@ bool TRestGeant4ParticleSource::ReadNewDecay0File(TString fileName) {
 
     TRestGeant4Particle particle;
 
-    debug << "Reading generator file : " << fileName << endl;
-    debug << "Total number of events : " << generatorEvents << endl;
+    RESTDebug << "Reading generator file : " << fileName << RESTendl;
+    RESTDebug << "Total number of events : " << generatorEvents << RESTendl;
     for (int n = 0; n < generatorEvents && !infile.eof(); n++) {
         int pos = -1;
         while (!infile.eof() && pos == -1) {
@@ -203,7 +203,7 @@ bool TRestGeant4ParticleSource::ReadNewDecay0File(TString fileName) {
 
         Int_t nParticles;
         infile >> nParticles;
-        debug << "Number of particles : " << nParticles << endl;
+        RESTDebug << "Number of particles : " << nParticles << RESTendl;
 
         // cout << evID <<" "<< time <<" "<< nParticles <<" "<< std::endl;
         for (int i = 0; i < nParticles && !infile.eof(); i++) {
@@ -215,11 +215,11 @@ bool TRestGeant4ParticleSource::ReadNewDecay0File(TString fileName) {
             Double_t time;
             infile >> pID >> time >> momx >> momy >> momz >> pName;
 
-            debug << " ---- New particle found --- " << endl;
-            debug << " Particle name : " << pName << endl;
-            debug << " - pId : " << pID << endl;
-            debug << " - Relative time : " << time << endl;
-            debug << " - px: " << momx << " py: " << momy << " pz: " << momz << " " << endl;
+            RESTDebug << " ---- New particle found --- " << RESTendl;
+            RESTDebug << " Particle name : " << pName << RESTendl;
+            RESTDebug << " - pId : " << pID << RESTendl;
+            RESTDebug << " - Relative time : " << time << RESTendl;
+            RESTDebug << " - px: " << momx << " py: " << momy << " pz: " << momz << " " << RESTendl;
 
             if (pID == 3) {
                 momentum2 = (momx * momx) + (momy * momy) + (momz * momz);
@@ -281,7 +281,7 @@ bool TRestGeant4ParticleSource::ReadOldDecay0File(TString fileName) {
         }
     }
     if (!headerFound) {
-        ferr << "TRestG4Metadata::ReadOldDecay0File. Problem reading generator file: no \"First event and "
+        RESTFerr << "TRestG4Metadata::ReadOldDecay0File. Problem reading generator file: no \"First event and "
                 "full number of events:\" header.\n";
         abort();
     }

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -103,8 +103,8 @@ void TRestGeant4ParticleSource::InitFromConfigFile() {
     if (((string)modelUse).find(".dat") != -1) {
         string fullPathName = SearchFile((string)modelUse);
         if (fullPathName == "") {
-            RESTFerr << "File not found : " << modelUse << RESTendl;
-            RESTFerr << "Decay0 generator file could not be found!!" << RESTendl;
+            RESTError << "File not found : " << modelUse << RESTendl;
+            RESTError << "Decay0 generator file could not be found!!" << RESTendl;
             exit(1);
         }
         modelUse = fullPathName;
@@ -178,7 +178,7 @@ bool TRestGeant4ParticleSource::ReadNewDecay0File(TString fileName) {
     }
 
     if (generatorEvents == 0) {
-        RESTFerr << "TRestG4Metadata::ReadNewDecay0File. Problem reading generator file" << RESTendl;
+        RESTError << "TRestG4Metadata::ReadNewDecay0File. Problem reading generator file" << RESTendl;
         exit(1);
     }
 
@@ -281,7 +281,7 @@ bool TRestGeant4ParticleSource::ReadOldDecay0File(TString fileName) {
         }
     }
     if (!headerFound) {
-        RESTFerr << "TRestG4Metadata::ReadOldDecay0File. Problem reading generator file: no \"First event and "
+        RESTError << "TRestG4Metadata::ReadOldDecay0File. Problem reading generator file: no \"First event and "
                 "full number of events:\" header.\n";
         abort();
     }

--- a/src/TRestGeant4PhysicsLists.cxx
+++ b/src/TRestGeant4PhysicsLists.cxx
@@ -138,25 +138,25 @@ Bool_t TRestGeant4PhysicsLists::PhysicsListExists(TString phName) {
 void TRestGeant4PhysicsLists::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
-    metadata << "Cut for electrons : " << fCutForElectron << " mm" << endl;
-    metadata << "Cut for positrons : " << fCutForPositron << " mm" << endl;
-    metadata << "Cut for gammas : " << fCutForGamma << " mm" << endl;
-    metadata << "Cut for muons : " << fCutForMuon << " mm" << endl;
-    metadata << "Cut for neutrons : " << fCutForNeutron << " mm" << endl;
-    metadata << "Min Energy for particle production: " << fMinEnergyRangeProductionCuts << " keV" << endl;
-    metadata << "Max Energy for particle production: " << fMaxEnergyRangeProductionCuts << " keV" << endl;
-    metadata << "---------------------------------------" << endl;
+    RESTMetadata << "Cut for electrons : " << fCutForElectron << " mm" << RESTendl;
+    RESTMetadata << "Cut for positrons : " << fCutForPositron << " mm" << RESTendl;
+    RESTMetadata << "Cut for gammas : " << fCutForGamma << " mm" << RESTendl;
+    RESTMetadata << "Cut for muons : " << fCutForMuon << " mm" << RESTendl;
+    RESTMetadata << "Cut for neutrons : " << fCutForNeutron << " mm" << RESTendl;
+    RESTMetadata << "Min Energy for particle production: " << fMinEnergyRangeProductionCuts << " keV" << RESTendl;
+    RESTMetadata << "Max Energy for particle production: " << fMaxEnergyRangeProductionCuts << " keV" << RESTendl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
     for (unsigned int n = 0; n < fPhysicsLists.size(); n++) {
-        metadata << "Physics list " << n << " : " << fPhysicsLists[n] << endl;
+        RESTMetadata << "Physics list " << n << " : " << fPhysicsLists[n] << RESTendl;
         vector<string> optList = TRestTools::GetOptions((string)fPhysicsListOptions[n]);
         for (unsigned int m = 0; m < optList.size(); m = m + 2)
-            metadata << " - Option " << m / 2 << " : " << optList[m] << " = " << optList[m + 1] << endl;
+            RESTMetadata << " - Option " << m / 2 << " : " << optList[m] << " = " << optList[m + 1] << RESTendl;
     }
-    if (fIonLimitStepList.size() > 0) metadata << "List of ions where step limit is affecting" << endl;
+    if (fIonLimitStepList.size() > 0) RESTMetadata << "List of ions where step limit is affecting" << RESTendl;
     for (unsigned int n = 0; n < fIonLimitStepList.size(); n++) {
-        metadata << "   - " << fIonLimitStepList[n] << endl;
+        RESTMetadata << "   - " << fIonLimitStepList[n] << RESTendl;
     }
-    metadata << "******************************************" << endl;
-    metadata << endl;
-    metadata << endl;
+    RESTMetadata << "******************************************" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << RESTendl;
 }


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Medium: 149](https://badgen.net/badge/PR%20Size/Medium%3A%20149/orange) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`