### PR TITLE
TRestGeant4Event. Fixing macros warnings

### DIFF
--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -208,7 +208,7 @@ class TRestGeant4Event : public TRestEvent {
     Bool_t ContainsParticle(const TString& particleName) const;
     Bool_t ContainsParticleInVolume(const TString& particleName, Int_t volumeID = -1) const;
 
-    void Initialize();
+    void Initialize() override;
 
     void InitializeReferences(TRestRun* run) override;
 
@@ -218,7 +218,7 @@ class TRestGeant4Event : public TRestEvent {
     void PrintActiveVolumes() const;
     void PrintEvent(int maxTracks = 0, int maxHits = 0) const;
 
-    inline TPad* DrawEvent(const TString& option = "") { return DrawEvent(option, true); }
+    inline TPad* DrawEvent(const TString& option = "") override { return DrawEvent(option, true); }
     TPad* DrawEvent(const TString& option, Bool_t autoBoundaries);
 
     // Constructor
@@ -226,6 +226,6 @@ class TRestGeant4Event : public TRestEvent {
     // Destructor
     virtual ~TRestGeant4Event();
 
-    ClassDef(TRestGeant4Event, 7);  // REST event superclass
+    ClassDefOverride(TRestGeant4Event, 7);  // REST event superclass
 };
 #endif


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/jgalan_macros_validation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/jgalan_macros_validation) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/jgalan_macros_validation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/jgalan_macros_validation) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_macros_validation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_macros_validation)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Merging the following PR should fix rest-for-physics/framework#292