### PR TITLE
Fix outdated methods in macros

### DIFF
--- a/macros/REST_Geant4_FindGammasEmitted.C
+++ b/macros/REST_Geant4_FindGammasEmitted.C
@@ -1,6 +1,7 @@
+#include <TRestTask.h>
+
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
-#include "TRestTask.h"
 
 #ifndef RestTask_Geant4_FindGammasEmitted
 #define RestTask_Geant4_FindGammasEmitted
@@ -72,10 +73,9 @@ Int_t REST_Geant4_FindGammasEmitted(TString fName) {
         for (int i = 0; i < event->GetNumberOfTracks(); i++) {
             tracks++;
             pName = event->GetTrack(i).GetParticleName();
-            Ek = event->GetTrack(i).GetKineticEnergy();
+            Ek = event->GetTrack(i).GetInitialKineticEnergy();
             if (pName == "gamma" && Ek > 3000 && Ek < 3500) {
                 h->Fill(Ek);
-                //               cout << "Is a gamma. Energy : " << Ek << " keV" << endl;
             }
         }
     }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-fix-macros/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-fix-macros) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-fix-macros/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-fix-macros) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-macros/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-macros)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Updated bad method name