### PR TITLE
New observable boundingSize inside TRestGeant4AnalysisProcess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LibraryVersion "1.8")
+set(LibraryVersion "1.9")
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
 if (${REST_DECAY0} MATCHES "ON")

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -240,6 +240,7 @@ class TRestGeant4Event : public TRestEvent {
 
     // Constructor
     TRestGeant4Event();
+
     // Destructor
     virtual ~TRestGeant4Event();
 

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -132,6 +132,8 @@ class TRestGeant4Event : public TRestEvent {
     void SetBoundaries(Double_t xMin, Double_t xMax, Double_t yMin, Double_t yMax, Double_t zMin,
                        Double_t zMax);
 
+    Double_t GetBoundingBoxSize();
+
     inline size_t GetNumberOfPrimaries() const { return fPrimaryParticleNames.size(); }
 
     inline TString GetPrimaryEventParticleName(size_t n = 0) const { return fPrimaryParticleNames[n]; }

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -148,8 +148,8 @@
 /// * **energyPrimary**: energy of the primary event generated.
 ///
 /// * **boundingSize**: It stores a value with the event size calculated
-/// as the size of a bounding box containing all the hits that produced
-/// an energy deposit.
+/// as the diagonal distance of a bounding box defined to contain all the
+/// hits that  produced an energy deposit.
 ///
 /// The following code ilustrates the addition of a primary event
 /// observable.

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -145,8 +145,11 @@
 ///
 /// * **thetaPrimary**: polar angle of the primary generated particle.
 /// * **phiPrimary**: azimuth angle of the primary generated particle.
-///
 /// * **energyPrimary**: energy of the primary event generated.
+///
+/// * **boundingSize**: It stores a value with the event size calculated
+/// as the size of a bounding box containing all the hits that produced
+/// an energy deposit.
 ///
 /// The following code ilustrates the addition of a primary event
 /// observable.

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -417,8 +417,6 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputG4Event = (TRestGeant4Event*)inputEvent;
     *fOutputG4Event = *((TRestGeant4Event*)inputEvent);
 
-    TString obsName;
-
     Double_t energy = fOutputG4Event->GetSensitiveVolumeEnergy();
 
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
@@ -456,8 +454,10 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue((string) "energyPrimary", energyPrimary);
 
     Double_t energyTotal = fOutputG4Event->GetTotalDepositedEnergy();
-    obsName = this->GetName() + (TString) ".totalEdep";
     SetObservableValue((string) "totalEdep", energyTotal);
+
+    Double_t size = fOutputG4Event->GetBoundingBoxSize();
+    SetObservableValue((string) "boundingSize", size);
 
     // process names as named by Geant4
     // processes present here will be added to the list of observables which can be used to see if the event
@@ -471,7 +471,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         if (processName.size() > 0) {
             processName[0] = toupper(processName[0]);
-            SetObservableValue("ContainsProcess" + processName, containsProcess);
+            SetObservableValue("containsProcess" + processName, containsProcess);
         }
     }
 
@@ -551,7 +551,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         cout << "----------------------------" << endl;
     }
 
-    // These cuts should be in another process or eliminated?!!
+    /// We should use here ApplyCut
     if (energy < fLowEnergyCut) return nullptr;
     if (fHighEnergyCut > 0 && energy > fHighEnergyCut) return nullptr;
 

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -463,12 +463,16 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     // processes present here will be added to the list of observables which can be used to see if the event
     // contains the process of interest.
     vector<string> processNames = {"phot", "compt"};
-    for (const auto& processName : processNames) {
+    for (auto& processName : processNames) {
         Int_t containsProcess = 0;
         if (fOutputG4Event->ContainsProcess(fG4Metadata->GetGeant4PhysicsInfo().GetProcessID(processName))) {
             containsProcess = 1;
         }
-        SetObservableValue("ContainsProcess" + processName, containsProcess);
+
+        if (processName.size() > 0) {
+            processName[0] = toupper(processName[0]);
+            SetObservableValue("ContainsProcess" + processName, containsProcess);
+        }
     }
 
     /*

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -281,6 +281,20 @@ void TRestGeant4Event::SetBoundaries(Double_t xMin, Double_t xMax, Double_t yMin
     fMaxZ = zMax;
 }
 
+///////////////////////////////////////////////
+/// \brief This method returns the event size as the size of the bounding box
+/// enclosing all hits.
+///
+Double_t TRestGeant4Event::GetBoundingBoxSize() {
+    SetBoundaries();
+
+    Double_t dX = fMaxX - fMinX;
+    Double_t dY = fMaxY - fMinY;
+    Double_t dZ = fMaxZ - fMinZ;
+
+    return TMath::Sqrt(dX * dX + dY * dY + dZ * dZ);
+}
+
 void TRestGeant4Event::SetBoundaries() {
     Double_t maxX = -1e10, minX = 1e10, maxZ = -1e10, minZ = 1e10, maxY = -1e10, minY = 1e10;
     Double_t minEnergy = 1e10, maxEnergy = -1e10;

--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -311,6 +311,8 @@ void TRestGeant4Event::SetBoundaries() {
 
             Double_t en = hits.GetEnergy(nhit);
 
+            if (en <= 0) continue;
+
             if (x > maxX) maxX = x;
             if (x < minX) minX = x;
             if (y > maxY) maxY = y;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 34](https://badgen.net/badge/PR%20Size/Ok%3A%2034/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/jgalan_analysis_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/jgalan_analysis_upgrade) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/jgalan_analysis_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/jgalan_analysis_upgrade) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_analysis_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_analysis_upgrade)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] Adding a new `boundingSize` observable that gives an idea of the event size.
- [x] Added method `TRestGeant4Event::GetBoundingBoxSize()`.