### PR TITLE
add `kill` option to volumes (detector section) to kill tracks after entering

### DIFF
--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -376,7 +376,7 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     ~TRestGeant4Metadata();
 
-    ClassDefOverride(TRestGeant4Metadata, 12);
+    ClassDefOverride(TRestGeant4Metadata, 13);
 
     // Allow modification of otherwise inaccessible / immutable members that shouldn't be modified by the user
     friend class SteppingAction;

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -341,6 +341,14 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     inline bool IsKillVolume(const char* volumeName) const { return fKillVolumes.count(volumeName) > 0; }
 
+    inline std::vector<std::string> GetKillVolumes() const {
+        std::vector<std::string> result;
+        for (const auto& volume : fKillVolumes) {
+            result.emplace_back(volume);
+        }
+        return result;
+    }
+
     inline std::vector<std::string> GetRemoveUnwantedTracksVolumesToKeep() const {
         std::vector<std::string> result;
         for (const auto& volume : fRemoveUnwantedTracksVolumesToKeep) {

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -154,6 +154,8 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// \brief A container related to fRemoveUnwantedTracks.
     std::set<std::string> fRemoveUnwantedTracksVolumesToKeep;
 
+    std::set<std::string> fKillVolumes;
+
     /// If this parameter is set to 'true' it will print out on screen every time 10k events are reached.
     Bool_t fPrintProgress = false;  //!
 
@@ -336,6 +338,8 @@ class TRestGeant4Metadata : public TRestMetadata {
     inline bool IsKeepTracksVolume(const char* volumeName) const {
         return fRemoveUnwantedTracksVolumesToKeep.count(volumeName) > 0;
     }
+
+    inline bool IsKillVolume(const char* volumeName) const { return fKillVolumes.count(volumeName) > 0; }
 
     inline std::vector<std::string> GetRemoveUnwantedTracksVolumesToKeep() const {
         std::vector<std::string> result;

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1128,6 +1128,12 @@ void TRestGeant4Metadata::ReadDetector() {
             isKeepTracks = StringToBool(isKeepTracksValue);
         }
 
+        bool isKill = false;
+        const string isKillValue = GetFieldValue("kill", volumeDefinition);
+        if (isKillValue != "Not defined") {
+            isKill = StringToBool(isKillValue);
+        }
+
         Double_t chance = StringToDouble(GetFieldValue("chance", volumeDefinition));
         if (chance == -1 || chance < 0) {
             chance = 1.0;
@@ -1146,6 +1152,9 @@ void TRestGeant4Metadata::ReadDetector() {
             }
             if (fRemoveUnwantedTracks && isKeepTracks) {
                 fRemoveUnwantedTracksVolumesToKeep.insert(physical);
+            }
+            if (isKill) {
+                fKillVolumes.insert(physical);
             }
         }
         volumeDefinition = GetNextElement(volumeDefinition);

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -593,6 +593,16 @@
 /// 	<volume sensitiveVolume="gas" maxStepSize="1mm" />
 /// \endcode
 ///
+/// The option `removeUnwantedTracks` can optionally be enabled inside detector section:
+///
+/// <detector><removeUnwantedTracks enabled="true" keepZeroEnergyTracks="true"/></detector>
+///
+/// This option will remove all tracks that do not deposit energy in any of the sensitive volumes or in any of
+/// the volumes marked as 'keepTracks' (for instance <volume name="veto" keepTracks="true" />).
+///
+/// By default tracks are removed if they do not deposit energy in these volumes but the parameter
+/// 'keepZeroEnergyTracks' can be set to true so that all processes are registered, for example a neutron
+/// capture taking place in one of the volumes which does not result in energy deposition.
 ///
 /// ## 4. The biasing volumes section (optional)
 ///

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -604,7 +604,7 @@
 /// 'keepZeroEnergyTracks' can be set to true so that all processes are registered, for example a neutron
 /// capture taking place in one of the volumes which does not result in energy deposition.
 ///
-/// The `kill="true"` option can be used in the volume definition (<volume name="shield" keepTracks="true" />)
+/// The `kill="true"` option can be used in the volume definition (<volume name="shield" kill="true" />)
 /// to stop a track after entering the volume. The track will be immediately killed and its energy deposition
 /// won't be computed. This is useful to speed up certain kinds of simulations.
 ///

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -604,6 +604,10 @@
 /// 'keepZeroEnergyTracks' can be set to true so that all processes are registered, for example a neutron
 /// capture taking place in one of the volumes which does not result in energy deposition.
 ///
+/// The `kill="true"` option can be used in the volume definition (<volume name="shield" keepTracks="true" />)
+/// to stop a track after entering the volume. The track will be immediately killed and its energy deposition
+/// won't be computed. This is useful to speed up certain kinds of simulations.
+///
 /// ## 4. The biasing volumes section (optional)
 ///
 /// The REST Geant4 toolkit (*restG4*) implements a particular biasing


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 36](https://badgen.net/badge/PR%20Size/Ok%3A%2036/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-kill-volume) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-kill-volume) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-kill-volume)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The `kill` option (boolean) has been added to volumes defined in detector section.

```
<volume name="volume" kill="true" />
```

When enabled the track will be killed upon entering the volume (or more generally in the first hit on the volume). The hit will be recorded with zero energy but the position time and momentum will be recorded. A new process called `REST-for-Physics-kill` is mocked in the stepping action to keep track of this.