### PR TITLE
Update progress printing logic

### DIFF
--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -128,12 +128,15 @@
 /// registered as a fully independent event. Therefore, the total number of
 /// registered events could be higher than the initial number of events.
 ///
-/// * **saveAllEvents**: If active, this parameter will mark all the volumes
+/// * **saveAllEvents**: If enabled, this parameter will mark all the volumes
 /// of the geometry as active, and it will ignore the energy range definition
 /// in the *detector* section. Any Geant4 simulated track from any event or
 /// subevent will be registered even if no energy deposition have been produced.
 /// In future, this parameter would be better implemented inside `<detector`
 /// definition.
+///
+/// * **printProgress**: if enabled, a message showing the progress of the simulation will be printed
+/// periodically. This option is enabled by default.
 ///
 /// The following example illustrates the definition of the common simulation
 /// parameters.
@@ -822,8 +825,8 @@ void TRestGeant4Metadata::InitFromConfigFile() {
     fSaveAllEvents = ToUpper(GetParameter("saveAllEvents", "false")) == "TRUE" ||
                      ToUpper(GetParameter("saveAllEvents", "off")) == "ON";
 
-    fPrintProgress = ToUpper(GetParameter("printProgress", "false")) == "TRUE" ||
-                     ToUpper(GetParameter("printProgress", "off")) == "ON";
+    fPrintProgress = ToUpper(GetParameter("printProgress", "true")) == "TRUE" ||
+                     ToUpper(GetParameter("printProgress", "on")) == "ON";
 
     fRegisterEmptyTracks = ToUpper(GetParameter("registerEmptyTracks", "false")) == "TRUE" ||
                            ToUpper(GetParameter("registerEmptyTracks", "off")) == "ON";


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-print-progress)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The periodic message showing simulation progress will be printed by default, controlled by the `printProgress` `TRestGeant4Metadata` parameter. Now it won't be printed if the verbosity is "silent".

- https://github.com/rest-for-physics/restG4/pull/79