### PR TITLE
Cut energies removed from analysis process

### DIFF
--- a/.github/pr-badge.yml
+++ b/.github/pr-badge.yml
@@ -15,7 +15,3 @@
   when: "$additions < 100"
 - imageUrl: "https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/$branchName/pipeline.svg"
   url: "https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/$branchName"
-- imageUrl: "https://gitlab.cern.ch/rest-for-physics/restG4/badges/$branchName/pipeline.svg"
-  url: "https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/$branchName"
-- imageUrl: "https://gitlab.cern.ch/rest-for-physics/framework/badges/$branchName/pipeline.svg"
-  url: "https://gitlab.cern.ch/rest-for-physics/framework/-/commits/$branchName"

--- a/.github/pr-badge.yml
+++ b/.github/pr-badge.yml
@@ -15,3 +15,5 @@
   when: "$additions < 100"
 - imageUrl: "https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/$branchName/pipeline.svg"
   url: "https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/$branchName"
+- imageUrl: "https://github.com/rest-for-physics/geant4lib/actions/workflows/validation.yml/badge.svg?branch=$branchName"
+  url: "https://github.com/rest-for-physics/geant4lib/commits/$branchName"

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -77,15 +77,6 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     /// A std::vector storing the `xxx` particle name extracted from `xxxTracksEDep`.
     std::vector<std::string> fParticleTrackEdep;  //!
 
-    // TODO these two thresholds should become OBSOLETE. We must use now the more generic
-    // way ApplyCut() with the <cut ...> definition at the RML process definition.
-
-    /// A low energy cut. Events below the threshold will be not further processed.
-    Double_t fLowEnergyCut;
-
-    /// A high energy cut. Events above the threshold will be not further processed.
-    Double_t fHighEnergyCut;
-
     Bool_t fPerProcessSensitiveEnergy = false;
     Bool_t fPerProcessSensitiveEnergyNorm = false;
 
@@ -128,6 +119,6 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     TRestGeant4AnalysisProcess(const char* configFilename);
     ~TRestGeant4AnalysisProcess();
 
-    ClassDefOverride(TRestGeant4AnalysisProcess, 2);
+    ClassDefOverride(TRestGeant4AnalysisProcess, 3);
 };
 #endif

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -80,8 +80,6 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     Bool_t fPerProcessSensitiveEnergy = false;
     Bool_t fPerProcessSensitiveEnergyNorm = false;
 
-    void InitFromConfigFile() override;
-
     void Initialize() override;
 
     void LoadDefaultConfig();

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -103,9 +103,6 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        RESTMetadata << "Low energy cut : " << fLowEnergyCut << " keV" << RESTendl;
-        RESTMetadata << "High energy cut : " << fHighEnergyCut << " keV" << RESTendl;
-
         EndPrintProcess();
     }
 

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -554,10 +554,6 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         cout << "----------------------------" << endl;
     }
 
-    /// We should use here ApplyCut
-    if (energy < fLowEnergyCut) return nullptr;
-    if (fHighEnergyCut > 0 && energy > fHighEnergyCut) return nullptr;
-
     return fOutputG4Event;
 }
 
@@ -579,9 +575,6 @@ void TRestGeant4AnalysisProcess::EndProcess() {
 /// TRestGeant4AnalysisProcess metadata section
 ///
 void TRestGeant4AnalysisProcess::InitFromConfigFile() {
-    fLowEnergyCut = GetDblParameterWithUnits("lowEnergyCut", (double)0);
-    fHighEnergyCut = GetDblParameterWithUnits("highEnergyCut", (double)0);
-
     if (GetParameter("perProcessSensitiveEnergy", "false") == "true") fPerProcessSensitiveEnergy = true;
     if (GetParameter("perProcessSensitiveEnergyNorm", "false") == "true")
         fPerProcessSensitiveEnergyNorm = true;

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -548,13 +548,3 @@ void TRestGeant4AnalysisProcess::EndProcess() {
     // Comment this if you don't want it.
     // TRestEventProcess::EndProcess();
 }
-
-///////////////////////////////////////////////
-/// \brief Function to read input parameters from the RML
-/// TRestGeant4AnalysisProcess metadata section
-///
-void TRestGeant4AnalysisProcess::InitFromConfigFile() {
-    if (GetParameter("perProcessSensitiveEnergy", "false") == "true") fPerProcessSensitiveEnergy = true;
-    if (GetParameter("perProcessSensitiveEnergyNorm", "false") == "true")
-        fPerProcessSensitiveEnergyNorm = true;
-}

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -29,27 +29,6 @@
 /// and metadata information and it will add the observables defined by
 /// the user to the analysisTree.
 ///
-/// ### Parameters
-///
-/// This process receives two optional parameters to define the energy
-/// range  of the events to be processed. Only the events that are within
-/// the range `(lowEnergyCut, highEnergyCut)` will be further
-/// considered. The events outside this energy range will be rejected, and
-/// will be not processed in future steps. The processing continues
-/// immediately to the next event.
-///
-/// The following lines of code ilustrate how to implement these
-/// parameters inside the TRestGeant4AnalysisProcess metadata section.
-///
-/// \code
-///    // Only events between 100keV-1MeV will be further considered
-///    <parameter name="lowEnergyCut" value="100" units="keV" >
-///    <parameter name="highEnergyCut" value="1" units="MeV" >
-/// \endcode
-///
-/// \note If these parameters are not defined the low and/or high energy
-/// cuts will be just ignored.
-///
 /// ### Observables
 ///
 /// This process includes generic observables by using a common pattern


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/badges/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/badges) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/badges/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/badges) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/badges/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/badges)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- `TRestGeant4AnalysisProcess`. Removing energy cuts that were introduced manually.
- Increasing class version
- Removed restG4 and framework GitLab pipeline badges from PR description.
- Added GitHub pipeline badge.