### PR TITLE
Fixing seg.fault due to wrong total hit counting

### DIFF
--- a/src/TRestGeant4Event.cxx
+++ b/src/TRestGeant4Event.cxx
@@ -305,6 +305,7 @@ void TRestGeant4Event::SetBoundaries() {
     Int_t nTHits = 0;
     for (unsigned int ntck = 0; ntck < this->GetNumberOfTracks(); ntck++) {
         Int_t nHits = GetTrack(ntck).GetNumberOfHits();
+        nTHits += nHits;
         const auto& hits = GetTrack(ntck).GetHits();
 
         for (int nhit = 0; nhit < nHits; nhit++) {
@@ -325,8 +326,6 @@ void TRestGeant4Event::SetBoundaries() {
 
             if (en > maxEnergy) maxEnergy = en;
             if (en < minEnergy) minEnergy = en;
-
-            nTHits++;
         }
     }
 


### PR DESCRIPTION
When using `DrawEvent` it seems that the `SetBoundaries` method was not counting hits with energy <=0, and this was producing a seg. fault.

Now `DrawEvent` works again for those events with hits with zero energy.