### PR TITLE
Add observables to record particle names and depth inside shielding

### DIFF
--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -80,6 +80,9 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     Bool_t fPerProcessSensitiveEnergy = false;
     Bool_t fPerProcessSensitiveEnergyNorm = false;
 
+    TVector3 fPrismCenter;
+    TVector3 fPrismSize;
+
     void Initialize() override;
 
     void LoadDefaultConfig();

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -80,8 +80,9 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     Bool_t fPerProcessSensitiveEnergy = false;
     Bool_t fPerProcessSensitiveEnergyNorm = false;
 
-    TVector3 fPrismCenter;
-    TVector3 fPrismSize;
+    // vectors for size and dimensions of prism used to compute "primaryOriginDistanceToPrism"
+    TVector3 fPrismCenter = {0, 0, 0};
+    TVector3 fPrismSize = {0, 0, 0};
 
     void Initialize() override;
 

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -387,6 +387,11 @@ void TRestGeant4AnalysisProcess::InitProcess() {
             fTracksEDepObservables.push_back(fObservables[i]);
             fParticleTrackEdep.emplace_back(particleName.Data());
         }
+
+        if (fObservables[i].find("primaryOriginDistanceToPrism") != string::npos) {
+            fPrismCenter = Get3DVectorParameterWithUnits("prismCenter");
+            fPrismSize = Get3DVectorParameterWithUnits("prismSizeXYZ");
+        }
     }
 }
 
@@ -436,6 +441,28 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     Double_t size = fOutputG4Event->GetBoundingBoxSize();
     SetObservableValue("boundingSize", size);
+
+    std::string eventPrimaryParticleName = fOutputG4Event->GetPrimaryEventParticleName(0).Data();
+    SetObservableValue("eventPrimaryParticleName", eventPrimaryParticleName);
+
+    std::string subEventPrimaryParticleName = fOutputG4Event->GetSubEventPrimaryEventParticleName().Data();
+    SetObservableValue("subEventPrimaryParticleName", subEventPrimaryParticleName);
+
+    auto observables = TRestEventProcess::ReadObservables();
+    auto it = std::find(observables.begin(), observables.end(), "primaryOriginDistanceToPrism");
+    if (it != observables.end()) {
+        TVector3 positionCentered = fOutputG4Event->GetPrimaryEventOrigin() - fPrismCenter;
+        double mx = TMath::Max(0., TMath::Max(-fPrismSize.X() / 2 - positionCentered.X(),
+                                              -fPrismSize.X() / 2 + positionCentered.X()));
+        double my = TMath::Max(0., TMath::Max(-fPrismSize.Y() / 2 - positionCentered.Y(),
+                                              -fPrismSize.Y() / 2 + positionCentered.Y()));
+        double mz = TMath::Max(0., TMath::Max(-fPrismSize.Z() / 2 - positionCentered.Z(),
+                                              -fPrismSize.Z() / 2 + positionCentered.Z()));
+
+        auto distance = TMath::Sqrt(mx * mx + my * my + mz * mz);
+
+        SetObservableValue("primaryOriginDistanceToPrism", distance);
+    }
 
     // process names as named by Geant4
     // processes present here will be added to the list of observables which can be used to see if the event


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 31](https://badgen.net/badge/PR%20Size/Ok%3A%2031/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-analysis/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-analysis) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/validation.yml/badge.svg?branch=lobis-analysis)](https://github.com/rest-for-physics/geant4lib/commits/lobis-analysis)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New observables introduced in `TRestGeant4AnalysisProcess`

1. `eventPrimaryParticleName` / `subEventPrimaryParticleName`: to record the particle name in the analysis tree.
2. `primaryOriginDistanceToPrism` distance of primary origin to a prism defined in the rml, useful to compute things such as depth inside shielding of primary.

Example:
```
<observable name="primaryOriginDistanceToPrism" value="ON"/>
<parameter name="prismCenter" value="(0,0,129.5)mm"/>
<parameter name="prismSizeXYZ" value="(194.0,170.0,340.0)mm"/>
```