### PR TITLE
TRestGeant4Metadata::PrintMetadata. Adding active volumes

### DIFF
--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -56,8 +56,6 @@ class TRestGeant4Metadata : public TRestMetadata {
     void ReadDetector();
     void ReadBiasing();
 
-    bool fDetectorSectionInitialized = false;  //!
-
     /// Class used to store and retrieve geometry info
     TRestGeant4GeometryInfo fGeant4GeometryInfo;
 

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1441,13 +1441,21 @@ void TRestGeant4Metadata::PrintMetadata() {
     } else {
         RESTMetadata << "Register empty tracks was NOT enabled" << RESTendl;
     }
+
+    RESTMetadata << " " << RESTendl;
     RESTMetadata << "   ++++++++++ Generator +++++++++++   " << RESTendl;
     RESTMetadata << "Number of generated events: " << GetNumberOfEvents() << RESTendl;
     fGeant4PrimaryGeneratorInfo.Print();
 
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "   ++++++++++ Active volumes +++++++++++   " << RESTendl;
+    for (int n = 0; n < fActiveVolumes.size(); n++)
+        RESTMetadata << " - Volume id : " << n << " name : " << fActiveVolumes[n] << RESTendl;
+
     for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();
 
     if (fDetectorSectionInitialized) {
+        RESTMetadata << " " << RESTendl;
         RESTMetadata << "   ++++++++++ Detector +++++++++++   " << RESTendl;
         RESTMetadata << "Energy range (keV): (" << GetMinimumEnergyStored() << ", "
                      << GetMaximumEnergyStored() << ")" << RESTendl;
@@ -1463,6 +1471,7 @@ void TRestGeant4Metadata::PrintMetadata() {
                          << ", chance: " << GetStorageChance(GetActiveVolumeName(n)) << RESTendl;
         }
     }
+
     for (unsigned int n = 0; n < GetNumberOfBiasingVolumes(); n++) {
         GetBiasingVolume(n).PrintBiasingVolume();
     }

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1411,8 +1411,6 @@ void TRestGeant4Metadata::ReadDetector() {
         }
     }
 
-    fDetectorSectionInitialized = true;
-
     if (GetNumberOfActiveVolumes() == 0) {
         RESTError << "No active volumes defined. Please check the detector section" << RESTendl;
         exit(1);
@@ -1454,22 +1452,20 @@ void TRestGeant4Metadata::PrintMetadata() {
 
     for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();
 
-    if (fDetectorSectionInitialized) {
-        RESTMetadata << " " << RESTendl;
-        RESTMetadata << "   ++++++++++ Detector +++++++++++   " << RESTendl;
-        RESTMetadata << "Energy range (keV): (" << GetMinimumEnergyStored() << ", "
-                     << GetMaximumEnergyStored() << ")" << RESTendl;
-        RESTMetadata << "Number of sensitive volumes: " << GetNumberOfSensitiveVolumes() << RESTendl;
-        for (const auto& sensitiveVolume : fSensitiveVolumes) {
-            RESTMetadata << "Sensitive volume: " << sensitiveVolume << RESTendl;
-        }
-        RESTMetadata << "Number of active volumes: " << GetNumberOfActiveVolumes() << RESTendl;
-        for (unsigned int n = 0; n < GetNumberOfActiveVolumes(); n++) {
-            RESTMetadata << "Name: " << GetActiveVolumeName(n)
-                         << ", ID: " << GetActiveVolumeID(GetActiveVolumeName(n))
-                         << ", maxStep: " << GetMaxStepSize(GetActiveVolumeName(n)) << "mm "
-                         << ", chance: " << GetStorageChance(GetActiveVolumeName(n)) << RESTendl;
-        }
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "   ++++++++++ Detector +++++++++++   " << RESTendl;
+    RESTMetadata << "Energy range (keV): (" << GetMinimumEnergyStored() << ", " << GetMaximumEnergyStored()
+                 << ")" << RESTendl;
+    RESTMetadata << "Number of sensitive volumes: " << GetNumberOfSensitiveVolumes() << RESTendl;
+    for (const auto& sensitiveVolume : fSensitiveVolumes) {
+        RESTMetadata << "Sensitive volume: " << sensitiveVolume << RESTendl;
+    }
+    RESTMetadata << "Number of active volumes: " << GetNumberOfActiveVolumes() << RESTendl;
+    for (unsigned int n = 0; n < GetNumberOfActiveVolumes(); n++) {
+        RESTMetadata << "Name: " << GetActiveVolumeName(n)
+                     << ", ID: " << GetActiveVolumeID(GetActiveVolumeName(n))
+                     << ", maxStep: " << GetMaxStepSize(GetActiveVolumeName(n)) << "mm "
+                     << ", chance: " << GetStorageChance(GetActiveVolumeName(n)) << RESTendl;
     }
 
     for (unsigned int n = 0; n < GetNumberOfBiasingVolumes(); n++) {

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1449,7 +1449,7 @@ void TRestGeant4Metadata::PrintMetadata() {
 
     RESTMetadata << " " << RESTendl;
     RESTMetadata << "   ++++++++++ Active volumes +++++++++++   " << RESTendl;
-    for (int n = 0; n < fActiveVolumes.size(); n++)
+    for (unsigned int n = 0; n < fActiveVolumes.size(); n++)
         RESTMetadata << " - Volume id : " << n << " name : " << fActiveVolumes[n] << RESTendl;
 
     for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1445,11 +1445,6 @@ void TRestGeant4Metadata::PrintMetadata() {
     RESTMetadata << "Number of generated events: " << GetNumberOfEvents() << RESTendl;
     fGeant4PrimaryGeneratorInfo.Print();
 
-    RESTMetadata << " " << RESTendl;
-    RESTMetadata << "   ++++++++++ Active volumes +++++++++++   " << RESTendl;
-    for (unsigned int n = 0; n < fActiveVolumes.size(); n++)
-        RESTMetadata << " - Volume id : " << n << " name : " << fActiveVolumes[n] << RESTendl;
-
     for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();
 
     RESTMetadata << " " << RESTendl;

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -33,9 +33,10 @@ TRestGeant4ParticleSource::TRestGeant4ParticleSource() = default;
 TRestGeant4ParticleSource::~TRestGeant4ParticleSource() = default;
 
 void TRestGeant4ParticleSource::PrintParticleSource() {
-    RESTMetadata << "---------------------------------------" << RESTendl;
-    RESTMetadata << "Particle Source Name: " << GetParticleName() << RESTendl;
-    if (!fParticlesTemplate.empty() || fGenFilename != "NO_SUCH_PARA") {
+    RESTMetadata << " " << RESTendl;
+    if (GetParticleName() != "" && GetParticleName() != "NO_SUCH_PARA")
+        RESTMetadata << "Particle Source Name: " << GetParticleName() << RESTendl;
+    if (!fParticlesTemplate.empty() && fGenFilename != "NO_SUCH_PARA") {
         RESTMetadata << "Generator file: " << GetGenFilename() << RESTendl;
         RESTMetadata << "Stored templates: " << fParticlesTemplate.size() << RESTendl;
         RESTMetadata << "Particles: ";

--- a/src/TRestGeant4ParticleSourceDecay0.cxx
+++ b/src/TRestGeant4ParticleSourceDecay0.cxx
@@ -11,7 +11,8 @@ TRestGeant4ParticleSourceDecay0::TRestGeant4ParticleSourceDecay0()
 
 void TRestGeant4ParticleSourceDecay0::PrintParticleSource() {
     metadata << "---------------------------------------" << endl;
-    metadata << "Particle Source Name: " << fParticleName << endl;
+    if (!fParticleName.empty() && fParticleName != "NO_SUCH_PARA")
+        metadata << "Particle Source Name: " << fParticleName << endl;
     metadata << "Parent Nuclide: " << fParentName << endl;
     metadata << "Decay Mode: " << fDecayType << endl;
     metadata << "Daughter Level: " << fDaughterLevel << endl;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 23](https://badgen.net/badge/PR%20Size/Ok%3A%2023/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/jgalan_printMetadata/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/jgalan_printMetadata) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/validation.yml/badge.svg?branch=jgalan_printMetadata)](https://github.com/rest-for-physics/geant4lib/commits/jgalan_printMetadata)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now `PrintMetadata` will also print out the active volume ids.