### PR TITLE
REST_Geant4_ViewEvent. Adding geometry warning

### DIFF
--- a/macros/REST_Geant4_ViewEvent.C
+++ b/macros/REST_Geant4_ViewEvent.C
@@ -11,6 +11,23 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Geant4_ViewEvent(TString fName) {
+    TFile* f = TFile::Open(fName);
+
+    TIter nextkey(f->GetListOfKeys());
+    TKey* key;
+    Bool_t containsGeometry = false;
+    while ((key = (TKey*)nextkey())) {
+        RESTDebug << "Reading key with name : " << key->GetName() << RESTendl;
+        RESTDebug << "Key type (class) : " << key->GetClassName() << RESTendl;
+
+        if (key->GetClassName() == (TString) "TGeoManager") containsGeometry = true;
+    }
+
+    if (!containsGeometry) {
+        RESTWarning << "The file you are trying to visualize does not contain a geometry file!" << RESTendl;
+        RESTWarning << "Are you opening the file generated direcly with restG4?" << RESTendl;
+    }
+
     TRestBrowser* browser = new TRestBrowser("TRestGeant4EventViewer");
 
     TRestEvent* eve = new TRestGeant4Event();


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 17](https://badgen.net/badge/PR%20Size/Ok%3A%2017/green) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/jgalan_macro_warning/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/jgalan_macro_warning) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/validation.yml/badge.svg?branch=jgalan_macro_warning)](https://github.com/rest-for-physics/geant4lib/commits/jgalan_macro_warning)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now the macro will print out a warning when the geometry is not found.

<img width="632" alt="Screenshot 2023-06-21 at 07 39 32" src="https://github.com/rest-for-physics/geant4lib/assets/12447509/00ff9953-9157-4c55-82b9-131e2134a9ad">
