### PR TITLE
correctly compute energy even after event data update (e.g. via quenc…

### DIFF
--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -47,7 +47,7 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     std::vector<Int_t> fVolumeID;  //!
 
     std::vector<std::string> fVolumeName;  //! A std::vector storing the name of active volumes.
-    
+
     /// It stores the name of observables (xxxMeanPosX,Y,Z) related to mean hits position in volume `xxx`.
     std::vector<std::string> fMeanPosObservables;  //!
 

--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -46,6 +46,8 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     /// A std::vector storing the active volume ids of observables `xxxVolumeEDep`.
     std::vector<Int_t> fVolumeID;  //!
 
+    std::vector<std::string> fVolumeName;  //! A std::vector storing the name of active volumes.
+    
     /// It stores the name of observables (xxxMeanPosX,Y,Z) related to mean hits position in volume `xxx`.
     std::vector<std::string> fMeanPosObservables;  //!
 

--- a/inc/TRestGeant4Event.h
+++ b/inc/TRestGeant4Event.h
@@ -160,7 +160,7 @@ class TRestGeant4Event : public TRestEvent {
     TRestGeant4Track* GetTrackByID(Int_t trackID) const;
 
     inline Double_t GetTotalDepositedEnergy() const { return fTotalDepositedEnergy; }
-    inline Double_t GetEnergyDepositedInVolume(Int_t volID) const { return fVolumeDepositedEnergy[volID]; }
+
     inline Double_t GetSensitiveVolumeEnergy() const { return fSensitiveVolumeEnergy; }
     TVector3 GetMeanPositionInVolume(Int_t volID) const;
     TVector3 GetFirstPositionInVolume(Int_t volID) const;
@@ -254,6 +254,7 @@ class TRestGeant4Event : public TRestEvent {
     void InsertStep(const G4Step*);    //!
 
     friend class OutputManager;
+    friend class TRestGeant4QuenchingProcess;
 
    private:
     std::map<Int_t, Int_t> fTrackIDToTrackIndex = {};

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -121,14 +121,17 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// deposit a non-zero energy on this volume will be registered.
     std::vector<TString> fSensitiveVolumes;
 
-    /// The number of events simulated, or to be simulated.
-    Int_t fNEvents = 0;
+    /// \brief The number of events simulated, or to be simulated.
+    Long64_t fNEvents = 0;
 
-    /// The number of events the user requested to be on the file
-    Int_t fNRequestedEntries = 0;
+    /// \brief The number of events the user requested to be on the file
+    Long64_t fNRequestedEntries = 0;
 
-    /// Time before simulation is ended and saved
+    /// \brief Time before simulation is ended and saved
     Int_t fSimulationMaxTimeSeconds = 0;
+
+    /// \brief The time, in seconds, that the simulation took to complete.
+    Long64_t fSimulationTime = 0;
 
     /// \brief The seed value used for Geant4 random event generator.
     /// If it is zero its value will be assigned using the system timestamp.
@@ -153,7 +156,8 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     std::set<std::string> fKillVolumes;
 
-    /// If this parameter is set to 'true' it will print out on screen every time 10k events are reached.
+    /// \brief If this parameter is set to 'true' it will print out on screen every time 10k events are
+    /// reached.
     Bool_t fPrintProgress = false;  //!
 
     /// \brief If this parameter is enabled it will register tracks with no hits inside. This is the default
@@ -161,7 +165,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// traceability, but saving disk space and likely improving computing performance for large events.
     Bool_t fRegisterEmptyTracks = true;
 
-    /// The world magnetic field
+    /// \brief The world magnetic field
     TVector3 fMagneticField = TVector3(0, 0, 0);
 
    public:
@@ -245,11 +249,13 @@ class TRestGeant4Metadata : public TRestMetadata {
     inline void SetMaterialsReference(std::string reference) { fMaterialsReference = reference; }
 
     /// Returns the number of events to be simulated.
-    inline Int_t GetNumberOfEvents() const { return fNEvents; }
+    inline Long64_t GetNumberOfEvents() const { return fNEvents; }
 
-    inline Int_t GetNumberOfRequestedEntries() const { return fNRequestedEntries; }
+    inline Long64_t GetNumberOfRequestedEntries() const { return fNRequestedEntries; }
 
     inline Int_t GetSimulationMaxTimeSeconds() const { return fSimulationMaxTimeSeconds; }
+
+    inline Long64_t GetSimulationTime() const { return fSimulationTime; }
 
     // Direct access to sources definition in primary generator
     ///////////////////////////////////////////////////////////
@@ -286,9 +292,9 @@ class TRestGeant4Metadata : public TRestMetadata {
     inline const std::vector<TString>& GetSensitiveVolumes() const { return fSensitiveVolumes; }
 
     /// Sets the name of the sensitive volume
-    inline void SetNumberOfEvents(Int_t n) { fNEvents = n; }
+    inline void SetNumberOfEvents(Long64_t n) { fNEvents = n; }
 
-    inline void SetNumberOfRequestedEntries(Int_t n) { fNRequestedEntries = n; }
+    inline void SetNumberOfRequestedEntries(Long64_t n) { fNRequestedEntries = n; }
 
     inline void SetSimulationMaxTimeSeconds(Int_t seconds) { fSimulationMaxTimeSeconds = seconds; }
 
@@ -373,6 +379,8 @@ class TRestGeant4Metadata : public TRestMetadata {
 
     void SetActiveVolume(const TString& name, Double_t chance, Double_t maxStep = 0);
 
+    void SetSimulationTime(Long64_t time) { fSimulationTime = time; }
+
     void PrintMetadata() override;
 
     void Merge(const TRestGeant4Metadata&);
@@ -385,7 +393,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     TRestGeant4Metadata(const TRestGeant4Metadata& metadata);
     TRestGeant4Metadata& operator=(const TRestGeant4Metadata& metadata);
 
-    ClassDefOverride(TRestGeant4Metadata, 14);
+    ClassDefOverride(TRestGeant4Metadata, 15);
 
     // Allow modification of otherwise inaccessible / immutable members that shouldn't be modified by the user
     friend class SteppingAction;

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -25,41 +25,34 @@
 
 #include <TRestEventProcess.h>
 
+#include <string>
+
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
 
+struct Veto {
+    std::string name;
+    std::string alias{};
+    std::string group{};
+    int layer{};
+    int number{};
+    TVector3 position{};
+    double length{};
+};
+
 class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
    private:
-    TString fVetoVolumesExpression;
-    TString fVetoDetectorsExpression;
-    double fVetoDetectorOffsetSize = 0;
-    double fVetoLightAttenuation = 0;
-    double fVetoQuenchingFactor = 1.0;
+    std::string fVetoVolumesExpression;  // identify veto volumes
 
    public:
-    inline TString GetVetoVolumesExpression() const { return fVetoVolumesExpression; }
-    inline TString GetVetoDetectorExpression() const { return fVetoDetectorsExpression; }
-    inline double GetVetoDetectorOffsetSize() const { return fVetoDetectorOffsetSize; }
-    inline double GetVetoLightAttenuation() const { return fVetoLightAttenuation; }
-    inline double GetVetoQuenchingFactor() const { return fVetoQuenchingFactor; }
-
-    inline void SetVetoVolumesExpression(const TString& expression) { fVetoVolumesExpression = expression; }
-    inline void SetVetoDetectorsExpression(const TString& expression) {
-        fVetoDetectorsExpression = expression;
-    }
-    inline void SetVetoDetectorOffsetSize(double offset) { fVetoDetectorOffsetSize = offset; }
-    inline void SetVetoLightAttenuation(double attenuation) { fVetoLightAttenuation = attenuation; }
-    inline void SetVetoQuenchingFactor(double quenchingFactor) { fVetoQuenchingFactor = quenchingFactor; }
+    inline std::string GetVetoVolumesExpression() const { return fVetoVolumesExpression; }
 
    private:
     TRestGeant4Event* fInputEvent = nullptr;               //!
     TRestGeant4Event* fOutputEvent = nullptr;              //!
     const TRestGeant4Metadata* fGeant4Metadata = nullptr;  //!
 
-    std::vector<TString> fVetoVolumes;
-    std::vector<TString> fVetoDetectorVolumes;
-    std::map<TString, TVector3> fVetoDetectorBoundaryPosition;
-    std::map<TString, TVector3> fVetoDetectorBoundaryDirection;
+    std::vector<Veto> fVetoVolumes;
 
     void InitFromConfigFile() override;
     void Initialize() override;
@@ -88,6 +81,6 @@ class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
     TRestGeant4VetoAnalysisProcess(const char* configFilename);
     ~TRestGeant4VetoAnalysisProcess();
 
-    ClassDefOverride(TRestGeant4VetoAnalysisProcess, 2);
+    ClassDefOverride(TRestGeant4VetoAnalysisProcess, 4);
 };
 #endif  // RestCore_TRestGeant4VetoAnalysisProcess

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -62,6 +62,8 @@ class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
     any GetInputEvent() const override { return fInputEvent; }
     any GetOutputEvent() const override { return fOutputEvent; }
 
+    static Veto GetVetoFromString(const std::string& vetoString);
+
     inline void SetGeant4Metadata(const TRestGeant4Metadata* metadata) {
         fGeant4Metadata = metadata;
     }  // TODO: We should not need this! but `GetMetadata<TRestGeant4Metadata>()` is not working early in the

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -99,7 +99,8 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
                 }
                 eventIdUpdates[mergeEvent->GetID()] = eventId;
                 cout << "WARNING: event ID " << mergeEvent->GetID() << " with sub-event ID "
-                     << mergeEvent->GetSubID() << " already exists. Changing to " << eventId << endl;
+                     << mergeEvent->GetSubID() << " already exists. Updating all instances of "
+                     << mergeEvent->GetID() << " to " << eventId << endl;
             }
             mergeEvent->SetID(eventId);
             eventIds.insert(mergeEvent->GetID());

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -291,6 +291,7 @@ void TRestGeant4AnalysisProcess::InitProcess() {
             if (volId >= 0) {
                 fEnergyInObservables.push_back(fObservables[i]);
                 fVolumeID.push_back(volId);
+                fVolumeName.push_back(volName.Data());
             }
 
             if (volId == -1) {
@@ -466,7 +467,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     }
 
     for (unsigned int n = 0; n < fEnergyInObservables.size(); n++) {
-        Double_t en = fOutputG4Event->GetEnergyDepositedInVolume(fVolumeID[n]);
+        Double_t en = fOutputG4Event->GetEnergyInVolume(fVolumeName[n]);
         string obsName = fEnergyInObservables[n];
         SetObservableValue(obsName, en);
     }

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1574,10 +1574,11 @@ size_t TRestGeant4Metadata::GetGeant4VersionMajor() const {
 
 void TRestGeant4Metadata::Merge(const TRestGeant4Metadata& metadata) {
     fIsMerge = true;
+    fSeed = 0;  // seed makes no sense in a merged file
 
     fNEvents += metadata.fNEvents;
     fNRequestedEntries += metadata.fNRequestedEntries;
-    fSeed = 0;  // seed makes no sense in a merged file
+    fSimulationTime += metadata.fSimulationTime;
 }
 
 TRestGeant4Metadata::TRestGeant4Metadata(const TRestGeant4Metadata& metadata) { *this = metadata; }

--- a/src/TRestGeant4NeutronTaggingProcess.cxx
+++ b/src/TRestGeant4NeutronTaggingProcess.cxx
@@ -228,7 +228,7 @@ TRestEvent* TRestGeant4NeutronTaggingProcess::ProcessEvent(TRestEvent* inputEven
         int id = fVetoVolumeIds[i];
         string volume_name = (string)fG4Metadata->GetActiveVolumeName(id);
 
-        Double_t energy = fOutputG4Event->GetEnergyDepositedInVolume(id);
+        Double_t energy = fOutputG4Event->GetEnergyInVolume(volume_name);
         volume_energy_map[volume_name] = energy;
     }
 

--- a/src/TRestGeant4VetoAnalysisProcess.cxx
+++ b/src/TRestGeant4VetoAnalysisProcess.cxx
@@ -197,7 +197,9 @@ void TRestGeant4VetoAnalysisProcess::Initialize() {
 /// corresponding TRestGeant4VetoAnalysisProcess section inside the RML.
 ///
 void TRestGeant4VetoAnalysisProcess::LoadConfig(const string& configFilename, const string& name) {
-    if (LoadConfigFromFile(configFilename, name)) LoadDefaultConfig();
+    if (LoadConfigFromFile(configFilename, name)) {
+        LoadDefaultConfig();
+    }
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestGeant4VetoAnalysisProcess.cxx
+++ b/src/TRestGeant4VetoAnalysisProcess.cxx
@@ -102,14 +102,14 @@ int findMostFrequent(const vector<int>& nums) {
     return mostFrequent;
 }
 
-Veto ExtractVetoFromString(const TString& input) {
+Veto TRestGeant4VetoAnalysisProcess::GetVetoFromString(const string& input) {
     // example input:
     // VetoSystem_vetoSystemEast_vetoLayerEast2_assembly-13.veto2_scintillatorVolume-1500.0mm-f1a5df68
 
     Veto veto;
     veto.name = input;
 
-    TObjArray* parts = input.Tokenize("_");
+    TObjArray* parts = TString(input).Tokenize("_");
 
     if (parts->GetEntries() >= 5) {
         TString group = ((TObjString*)parts->At(1))->GetString();
@@ -227,7 +227,7 @@ void TRestGeant4VetoAnalysisProcess::InitProcess() {
             for (const auto& physicalVolume : geometryInfo.GetAllPhysicalVolumesFromLogical(logicalVolume)) {
                 const string name =
                     geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolume).Data();
-                Veto veto = ExtractVetoFromString(name);
+                Veto veto = GetVetoFromString(name);
                 veto.position = geometryInfo.GetPosition(name);
                 fVetoVolumes.push_back(veto);
             }
@@ -283,7 +283,7 @@ TRestEvent* TRestGeant4VetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent)
     // compute max energy for each group
     map<string, double> vetoGroupMaxEnergyMap;
     for (const auto& [name, energy] : vetoEnergyMap) {
-        const auto veto = ExtractVetoFromString(name);
+        const auto veto = GetVetoFromString(name);
         if (vetoGroupMaxEnergyMap[veto.group] < energy) {
             vetoGroupMaxEnergyMap[veto.group] = energy;
         }
@@ -295,7 +295,7 @@ TRestEvent* TRestGeant4VetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent)
     // compute max energy for each group layer
     map<pair<string, int>, double> vetoGroupLayerMaxEnergyMap;
     for (const auto& [name, energy] : vetoEnergyMap) {
-        const auto veto = ExtractVetoFromString(name);
+        const auto veto = GetVetoFromString(name);
         if (vetoGroupLayerMaxEnergyMap[make_pair(veto.group, veto.layer)] < energy) {
             vetoGroupLayerMaxEnergyMap[make_pair(veto.group, veto.layer)] = energy;
         }
@@ -309,7 +309,7 @@ TRestEvent* TRestGeant4VetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent)
     // compute max energy for each layer (all groups)
     map<int, double> vetoLayerMaxEnergyMap;
     for (const auto& [name, energy] : vetoEnergyMap) {
-        const auto veto = ExtractVetoFromString(name);
+        const auto veto = GetVetoFromString(name);
         if (vetoLayerMaxEnergyMap[veto.layer] < energy) {
             vetoLayerMaxEnergyMap[veto.layer] = energy;
         }

--- a/src/TRestGeant4VetoAnalysisProcess.cxx
+++ b/src/TRestGeant4VetoAnalysisProcess.cxx
@@ -348,13 +348,27 @@ TRestEvent* TRestGeant4VetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent)
     SetObservableValue("nCapturesInCaptureVolumesTimes", nCapturesInCaptureVolumesTimes);
     // cannot insert a vector of vectors, need to flatten it
     std::vector<float> nCapturesInCaptureVolumesChildGammaEnergiesFlat;
+    std::vector<int> nCapturesInCaptureVolumesChildGammaCount;
     for (const auto& v : nCapturesInCaptureVolumesChildGammaEnergies) {
         nCapturesInCaptureVolumesChildGammaEnergiesFlat.insert(
             nCapturesInCaptureVolumesChildGammaEnergiesFlat.end(), v.begin(), v.end());
+        nCapturesInCaptureVolumesChildGammaCount.push_back(v.size());
     }
+
+    float nCapturesInCaptureVolumesChildGammaCountAverage = 0;
+    for (const auto& v : nCapturesInCaptureVolumesChildGammaCount) {
+        nCapturesInCaptureVolumesChildGammaCountAverage +=
+            float(v) / nCapturesInCaptureVolumesChildGammaCount.size();
+    }
+
     SetObservableValue("nCapturesInCaptureVolumesChildGammaEnergies",
                        nCapturesInCaptureVolumesChildGammaEnergiesFlat);
-    SetObservableValue("nCapturesInCaptureVolumesChildGammaCount",
+    SetObservableValue("nCapturesInCaptureVolumesChildGammaCount", nCapturesInCaptureVolumesChildGammaCount);
+    SetObservableValue("nCapturesInCaptureVolumesChildGammaCountAverage",
+                       nCapturesInCaptureVolumesChildGammaCountAverage);
+    SetObservableValue("nCapturesInCaptureVolumesChildGammaCountMostFrequent",
+                       findMostFrequent(nCapturesInCaptureVolumesChildGammaCount));
+    SetObservableValue("nCapturesInCaptureVolumesChildGammaCountTotal",
                        nCapturesInCaptureVolumesChildGammaEnergiesFlat.size());
 
     SetObservableValue("nCapturesInCaptureVolumesChildGammasEnergyInVetos",

--- a/test/src/Geant4AnalysisProcesses.cxx
+++ b/test/src/Geant4AnalysisProcesses.cxx
@@ -32,11 +32,7 @@ TEST(TRestGeant4VetoAnalysisProcess, Default) {
 
     process.PrintMetadata();
 
-    EXPECT_TRUE(process.GetVetoVolumesExpression().IsNull());
-    EXPECT_TRUE(process.GetVetoDetectorExpression().IsNull());
-    EXPECT_TRUE(process.GetVetoDetectorOffsetSize() == 0);
-    EXPECT_TRUE(process.GetVetoLightAttenuation() == 0);
-    EXPECT_TRUE(process.GetVetoQuenchingFactor() == 1.0);
+    EXPECT_TRUE(process.GetVetoVolumesExpression().empty());
 }
 
 TEST(TRestGeant4VetoAnalysisProcess, FromRml) {
@@ -45,10 +41,6 @@ TEST(TRestGeant4VetoAnalysisProcess, FromRml) {
     process.PrintMetadata();
 
     EXPECT_TRUE(process.GetVetoVolumesExpression() == "^scintillatorVolume");
-    EXPECT_TRUE(process.GetVetoDetectorExpression() == "^scintillatorLightGuideVolume");
-    EXPECT_TRUE(process.GetVetoDetectorOffsetSize() == 0);
-    EXPECT_TRUE(process.GetVetoLightAttenuation() == 0);
-    EXPECT_TRUE(process.GetVetoQuenchingFactor() == 0);
 }
 
 TEST(TRestGeant4VetoAnalysisProcess, Simulation) {
@@ -57,10 +49,6 @@ TEST(TRestGeant4VetoAnalysisProcess, Simulation) {
     TRestGeant4VetoAnalysisProcess process(processRmlFile.c_str());
 
     EXPECT_TRUE(process.GetVetoVolumesExpression() == "^scintillatorVolume");
-    EXPECT_TRUE(process.GetVetoDetectorExpression() == "^scintillatorLightGuideVolume");
-    EXPECT_TRUE(process.GetVetoDetectorOffsetSize() == 0);
-    EXPECT_TRUE(process.GetVetoLightAttenuation() == 0);
-    EXPECT_TRUE(process.GetVetoQuenchingFactor() == 0);
 
     TRestRun run(simulationFile.c_str());
     run.GetInputFile()->ls();


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Large: 455](https://badgen.net/badge/PR%20Size/Large%3A%20455/red) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-fix-energy-compute)](https://github.com/rest-for-physics/geant4lib/commits/lobis-fix-energy-compute)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I noticed a problem when computing observables such as energy deposition via the `TRestGeant4AnalysisProcess` after the geant4 event has been modified (for example via the quenching process). Even though the process updates the energy of each individual hit, the energy deposited is retrieved from a pre-computed store. This is done for efficiency but it can be problematic as processes that modify the event will also need to update these stores.

On top of that, currently there are two stores that serve a similar purpose: one only for energy in volume, one newer that serves for everything and gets proyected into whatever the user requests (energy per particle, per process, etc.). The newer store is more computationally expensive but at the end both are fast enough not to be a problem. We should aim to remove this redundancy (I tried but it was very complex, it needs a deep revision).

In general the problem lies with the usage of volume ids (which can be active volume ids or just volume ids...) instead of just using the volume names (which would lower confusion). I think we should just use volume names everywhere possible unless there is a good reason not to.