### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -90,8 +90,8 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fInputG4Event; }
-    any GetOutputEvent() const override { return fOutputG4Event; }
+    RESTValue GetInputEvent() const override { return fInputG4Event; }
+    RESTValue GetOutputEvent() const override { return fOutputG4Event; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestGeant4BlobAnalysisProcess.h
+++ b/inc/TRestGeant4BlobAnalysisProcess.h
@@ -40,8 +40,8 @@ class TRestGeant4BlobAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fG4Event; }
-    any GetOutputEvent() const override { return fG4Event; }
+    RESTValue GetInputEvent() const override { return fG4Event; }
+    RESTValue GetOutputEvent() const override { return fG4Event; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestGeant4NeutronTaggingProcess.h
+++ b/inc/TRestGeant4NeutronTaggingProcess.h
@@ -92,8 +92,8 @@ class TRestGeant4NeutronTaggingProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fInputG4Event; }
-    any GetOutputEvent() const override { return fOutputG4Event; }
+    RESTValue GetInputEvent() const override { return fInputG4Event; }
+    RESTValue GetOutputEvent() const override { return fOutputG4Event; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestGeant4QuenchingProcess.h
+++ b/inc/TRestGeant4QuenchingProcess.h
@@ -56,8 +56,8 @@ class TRestGeant4QuenchingProcess : public TRestEventProcess {
                                                    const std::string& particleName) const;
 
     //
-    any GetInputEvent() const override { return fInputG4Event; }
-    any GetOutputEvent() const override { return fOutputG4Event; }
+    RESTValue GetInputEvent() const override { return fInputG4Event; }
+    RESTValue GetOutputEvent() const override { return fOutputG4Event; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestGeant4VetoAnalysisProcess.h
+++ b/inc/TRestGeant4VetoAnalysisProcess.h
@@ -59,8 +59,8 @@ class TRestGeant4VetoAnalysisProcess : public TRestEventProcess {
     void LoadDefaultConfig();
 
    public:
-    any GetInputEvent() const override { return fInputEvent; }
-    any GetOutputEvent() const override { return fOutputEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputEvent; }
 
     static Veto GetVetoFromString(const std::string& vetoString);
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 10](https://badgen.net/badge/PR%20Size/Ok%3A%2010/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=any_to_RESTValue)](https://github.com/rest-for-physics/geant4lib/commits/any_to_RESTValue)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR https://github.com/rest-for-physics/framework/pull/471