### PR TITLE
Merge supports analysis files

### DIFF
--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -59,6 +59,7 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
 
     TRestGeant4Event* mergeEvent = nullptr;
     auto mergeEventTree = mergeRun->GetEventTree();
+    auto mergeAnalysisTree = mergeRun->GetAnalysisTree();
     mergeEventTree->Branch("TRestGeant4EventBranch", "TRestGeant4Event", &mergeEvent);
 
     set<Int_t> eventIds;  // std::set is sorted from lower to higher automatically
@@ -80,6 +81,7 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
         }
         TRestGeant4Event* event = nullptr;
         auto eventTree = run.GetEventTree();
+        // auto analysisTree = run.GetAnalysisTree();
         eventTree->SetBranchAddress("TRestGeant4EventBranch", &event);
         for (int j = 0; j < eventTree->GetEntries(); j++) {
             eventTree->GetEntry(j);
@@ -106,7 +108,8 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
             eventIds.insert(mergeEvent->GetID());
 
             mergeEventTree->Fill();
-            mergeRun->GetAnalysisTree()->Fill();
+            // TODO: this just adds empty entries to the analysis tree. It should be merged
+            mergeAnalysisTree->Fill();
 
             eventCounter++;
         }
@@ -123,9 +126,9 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
                         // This is merged and added later
                         continue;
                     }
-                    const auto metadata = (TRestMetadata*)obj;
+                    const auto metadataKey = (TRestMetadata*)obj;
                     mergeRun->GetOutputFile()->cd();
-                    metadata->Write(metadata->GetName(), TObject::kOverwrite);
+                    metadataKey->Write();
                 }
             }
         }

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -119,8 +119,8 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
 
     gGeoManager->Write("Geometry", TObject::kOverwrite);
 
-    mergeMetadata.SetName("geant4Metadata");
     mergeMetadata.Write();
+
     mergeRun->UpdateOutputFile();
     mergeRun->CloseFile();
 

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -110,6 +110,25 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
 
             eventCounter++;
         }
+
+        // add the remaining metadata of the first file to the merged file
+        if (i == 0) {
+            // iterate over all keys of the file to find inheritance of TRestMetadata
+            TIter nextkey(run.GetInputFile()->GetListOfKeys());
+            TKey* key;
+            while ((key = (TKey*)nextkey())) {
+                const auto obj = key->ReadObj();
+                if (obj->InheritsFrom("TRestMetadata")) {
+                    if (obj->InheritsFrom("TRestGeant4Metadata")) {
+                        // This is merged and added later
+                        continue;
+                    }
+                    const auto metadata = (TRestMetadata*)obj;
+                    mergeRun->GetOutputFile()->cd();
+                    metadata->Write(metadata->GetName(), TObject::kOverwrite);
+                }
+            }
+        }
     }
 
     cout << "Output filename: " << mergeRun->GetOutputFileName() << endl;

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -136,7 +136,9 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
 
     mergeRun->GetOutputFile()->cd();
 
-    gGeoManager->Write("Geometry", TObject::kOverwrite);
+    if (gGeoManager != nullptr) {
+        gGeoManager->Write("Geometry", TObject::kOverwrite);
+    }
 
     mergeMetadata.Write();
 
@@ -150,8 +152,6 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
              << ") does not match the number of events in the input files (" << eventCounter << ")" << endl;
         exit(1);
     }
-    cout << "Number of events in the output file: " << runCheck.GetEntries() << " matches internal count"
-         << endl;
 }
 
 #endif

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1576,6 +1576,10 @@ void TRestGeant4Metadata::Merge(const TRestGeant4Metadata& metadata) {
     fIsMerge = true;
     fSeed = 0;  // seed makes no sense in a merged file
 
+    if (fName.IsNull()) {
+        fName = metadata.fName;
+    }
+
     fNEvents += metadata.fNEvents;
     fNRequestedEntries += metadata.fNRequestedEntries;
     fSimulationTime += metadata.fSimulationTime;
@@ -1585,6 +1589,7 @@ TRestGeant4Metadata::TRestGeant4Metadata(const TRestGeant4Metadata& metadata) { 
 
 TRestGeant4Metadata& TRestGeant4Metadata::operator=(const TRestGeant4Metadata& metadata) {
     fIsMerge = metadata.fIsMerge;
+    fName = metadata.fName;
     fGeant4GeometryInfo = metadata.fGeant4GeometryInfo;
     fGeant4PhysicsInfo = metadata.fGeant4PhysicsInfo;
     fGeant4PrimaryGeneratorInfo = metadata.fGeant4PrimaryGeneratorInfo;


### PR DESCRIPTION
Enabling merging of analysis files:

- Only `TRestGeant4Metadata` is actually merged, for the others the merge logic assumes they are identical and the first one is carried over to the merge file. It should work fine for most cases as in general metadata classes are not dependant on the data from the file but in some cases (such as `TRestGeant4Metadata::NEntries`, etc.) it can be a problem.