### PR TITLE
Implementing CRY generator as a new source inside `TRestGeant4ParticleSourceCry`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,33 @@ if (NOT ${REST_EVE} MATCHES "ON")
     set(excludes ${excludes} TRestGeant4EventViewer)
 endif ()
 
+if (DEFINED REST_CRY_PATH)
+    find_path(CRY_LIB_PATH libCRY.a HINTS ${REST_CRY_PATH}/lib)
+
+    find_path(CRY_INC_PATH CRYGenerator.h HINTS ${REST_CRY_PATH}/src)
+
+    if (CRY_LIB_PATH AND CRY_INC_PATH)
+        message(STATUS "Found CRY includes in ${CRY_INC_PATH}")
+        message(STATUS "Found CRY library in ${CRY_LIB_PATH}")
+
+		add_compile_definitions("USE_CRY")
+        add_compile_definitions("CRY_DATA_PATH=\"${REST_CRY_PATH}/data\"")
+
+		set(external_include_dirs ${external_include_dirs} ${CRY_INC_PATH})
+		set(external_libs "${external_libs} -L${CRY_LIB_PATH} -lCRY")
+
+		set(feature_added "Cry")
+		set(feature_added
+			${feature_added}
+			PARENT_SCOPE)
+    else ()
+        message(
+            FATAL_ERROR
+                "REST_CRY_PATH was defined with path ${REST_CRY_PATH}, but CRY library was not found there!\n"
+        )
+    endif ()
+endif (DEFINED REST_CRY_PATH)
+
 compilelib("")
 
 file(GLOB_RECURSE MAC "${CMAKE_CURRENT_SOURCE_DIR}/macros/*")

--- a/inc/TRestGeant4Particle.h
+++ b/inc/TRestGeant4Particle.h
@@ -1,17 +1,24 @@
-//////////////////////////////////////////////////////////////////////////
-///
-///             RESTSoft : Software for Rare Event Searches with TPCs
-///
-///             TRestGeant4Particle.h
-///
-///             Class to store a particle definition
-///
-///             jul 2015:   First concept
-///                 Created as part of the conceptualization of existing REST
-///                 software.
-///                 J. Galan
-///
-//////////////////////////////////////////////////////////////////////////
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
 
 #ifndef RestCore_TRestGeant4Particle
 #define RestCore_TRestGeant4Particle
@@ -21,6 +28,7 @@
 
 #include <iostream>
 
+/// A class used to store particle properties
 class TRestGeant4Particle {
    protected:
     TString fParticleName;
@@ -38,15 +46,10 @@ class TRestGeant4Particle {
     inline Int_t GetParticleCharge() const { return fCharge; }
     inline TVector3 GetOrigin() const { return fOrigin; }
 
-    void SetParticle(TRestGeant4Particle particle) {
-        fExcitationLevel = particle.GetExcitationLevel();
-        fParticleName = particle.GetParticleName();
-        fEnergy = particle.GetEnergy();
-        fDirection = particle.GetMomentumDirection();
-        fOrigin = particle.fOrigin;
-    }
+    void SetParticle(TRestGeant4Particle particle);
 
     void SetParticleName(TString particle) { fParticleName = particle; }
+
     void SetExcitationLevel(Double_t excitationEnergy) {
         fExcitationLevel = excitationEnergy;
         if (fExcitationLevel < 0) fExcitationLevel = 0;
@@ -57,6 +60,8 @@ class TRestGeant4Particle {
     void SetDirection(TVector3 dir) { fDirection = dir; }
     void SetEnergy(Double_t en) { fEnergy = en; }
     void SetOrigin(TVector3 pos) { fOrigin = pos; }
+
+    void Print() const;
 
     // Constructor
     TRestGeant4Particle();

--- a/inc/TRestGeant4ParticleSource.h
+++ b/inc/TRestGeant4ParticleSource.h
@@ -194,7 +194,7 @@ class TRestGeant4ParticleSource : public TRestGeant4Particle, public TRestMetada
         fParticles.clear();
     }
 
-    virtual void PrintParticleSource();
+    virtual void PrintMetadata() override;
 
     // Constructor
     TRestGeant4ParticleSource();

--- a/inc/TRestGeant4ParticleSource.h
+++ b/inc/TRestGeant4ParticleSource.h
@@ -62,7 +62,7 @@ class TRestGeant4ParticleSource : public TRestGeant4Particle, public TRestMetada
 
    public:
     virtual void Update();
-    virtual void InitFromConfigFile();
+    virtual void InitFromConfigFile() override;
     static TRestGeant4ParticleSource* instantiate(std::string model = "");
 
     inline TVector3 GetDirection() const {
@@ -201,6 +201,6 @@ class TRestGeant4ParticleSource : public TRestGeant4Particle, public TRestMetada
     // Destructor
     virtual ~TRestGeant4ParticleSource();
 
-    ClassDef(TRestGeant4ParticleSource, 5);
+    ClassDefOverride(TRestGeant4ParticleSource, 5);
 };
 #endif

--- a/inc/TRestGeant4ParticleSourceCry.h
+++ b/inc/TRestGeant4ParticleSourceCry.h
@@ -1,9 +1,9 @@
 #ifndef TRestParticleSourceCry_Class
 #define TRestParticleSourceCry_Class
 
-#include <iostream>
-
 #include <TRandom3.h>
+
+#include <iostream>
 
 #ifdef USE_CRY
 #include <CRYGenerator.h>
@@ -13,51 +13,54 @@
 #include <TRestGeant4ParticleSource.h>
 
 class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
-	private:
-		/// It defines if secondary neutrons will be produced by the generator
-		Int_t fReturnNeutrons = 1;
-		/// It defines if secondary protons will be produced by the generator
-		Int_t fReturnProtons = 1;
-		/// It defines if secondary photons will be produced by the generator
-		Int_t fReturnGammas = 1;
-		/// It defines if secondary gammas will be produced by the generator
-		Int_t fReturnElectrons = 1;
-		/// It defines if secondary electrons will be produced by the generator
-		Int_t fReturnPions = 1;
-		/// It defines if secondary pions will be produced by the generator
-		Int_t fReturnKaons = 1;
-		/// It defines if secondary muons will be produced by the generator
-		Int_t fReturnMuons = 1;
+   private:
+    /// It defines if secondary neutrons will be produced by the generator
+    Int_t fReturnNeutrons = 1;
+    /// It defines if secondary protons will be produced by the generator
+    Int_t fReturnProtons = 1;
+    /// It defines if secondary photons will be produced by the generator
+    Int_t fReturnGammas = 1;
+    /// It defines if secondary gammas will be produced by the generator
+    Int_t fReturnElectrons = 1;
+    /// It defines if secondary electrons will be produced by the generator
+    Int_t fReturnPions = 1;
+    /// It defines if secondary pions will be produced by the generator
+    Int_t fReturnKaons = 1;
+    /// It defines if secondary muons will be produced by the generator
+    Int_t fReturnMuons = 1;
 
-		/// Showers with number of particles below this number will be truncated.
-		Int_t fNParticlesMin = 1;
-		/// Showers with number of particles above this number will be truncated.
-		Int_t fNParticlesMax = 1000000;
+    /// Showers with number of particles below this number will be truncated.
+    Int_t fNParticlesMin = 1;
+    /// Showers with number of particles above this number will be truncated.
+    Int_t fNParticlesMax = 1000000;
 
-		/// This is likely the X-coordinate where the box of generated particles is centered.
-		Double_t fXOffset = 0;
-		/// This is likely the Y-coordinate where the box of generated particles is centered.
-		Double_t fYOffset = 0;
-		/// This is likely the Z-coordinate where the box of generated particles is centered.
-		Double_t fZOffset = 0;
+    /// This is likely the X-coordinate where the box of generated particles is centered.
+    Double_t fXOffset = 0;
+    /// This is likely the Y-coordinate where the box of generated particles is centered.
+    Double_t fYOffset = 0;
+    /// This is likely the Z-coordinate where the box of generated particles is centered.
+    Double_t fZOffset = 0;
 
-		/// It will adjust the cosmic-ray distributions to the 11-year solar cycle.
-		std::string fDate = "7-1-2012";
+    /// It will adjust the cosmic-ray distributions to the 11-year solar cycle.
+    std::string fDate = "7-1-2012";
 
-		/// The allowed range is -90 to 90. 0 defines the magnetic equator.
-		Double_t fLatitude = 90.0;;
+    /// The allowed range is -90 to 90. 0 defines the magnetic equator.
+    Double_t fLatitude = 90.0;
+    ;
 
-		/// Allowed values are 0, 2100 and 11300 m.
-		Double_t fAltitude = 0.0;;
+    /// Allowed values are 0, 2100 and 11300 m.
+    Double_t fAltitude = 0.0;
+    ;
 
-		/// The size of the box where the CRY generator produces particles (in m).
-		Double_t fSubBoxLength = 100.0;;
+    /// The size of the box where the CRY generator produces particles (in m).
+    Double_t fSubBoxLength = 100.0;
+    ;
 
-		/// Seed used in random generator
-		Int_t fSeed = 0;  //<
+    /// Seed used in random generator
+    Int_t fSeed = 0;  //<
 
-		/// Internal process random generator
-		TRandom3* fRandom = nullptr;  //!
+    /// Internal process random generator
+    TRandom3* fRandom = nullptr;  //!
 
    protected:
 #ifdef USE_CRY

--- a/inc/TRestGeant4ParticleSourceCry.h
+++ b/inc/TRestGeant4ParticleSourceCry.h
@@ -42,7 +42,7 @@ class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
     Double_t fZOffset = 0;
 
     /// It will adjust the cosmic-ray distributions to the 11-year solar cycle.
-    std::string fDate = "7-1-2012";
+    std::string fDate = "7\1\2012";
 
     /// The allowed range is -90 to 90. 0 defines the magnetic equator.
     Double_t fLatitude = 90.0;

--- a/inc/TRestGeant4ParticleSourceCry.h
+++ b/inc/TRestGeant4ParticleSourceCry.h
@@ -11,6 +11,29 @@
 #include <TRestGeant4ParticleSource.h>
 
 class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
+	private:
+		Int_t fReturnNeutrons = 1;
+		Int_t fReturnProtons = 1;
+		Int_t fReturnGammas = 1;
+		Int_t fReturnElectrons = 1;
+		Int_t fReturnPions = 1;
+		Int_t fReturnKaons = 1;
+		Int_t fReturnMuons = 1;
+
+		Int_t fNParticlesMin = 1;
+		Int_t fNParticlesMax = 1000000;
+
+		Double_t fXOffset = 0;
+		Double_t fYOffset = 0;
+		Double_t fZOffset = 0;
+
+		std::string fDate = "7-1-2012";
+
+		Double_t fLatitude = 90.0;;
+		Double_t fAltitude = 0.0;;
+
+		Double_t fSubBoxLength = 100.0;;
+
    protected:
 #ifdef USE_CRY
     CRYGenerator* fCRYGenerator = nullptr;
@@ -20,7 +43,7 @@ class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
     void Update() override;
     void InitFromConfigFile() override;
     inline Int_t GetNumberOfParticles() const { return fParticles.size(); }
-    void PrintParticleSource() override;
+    void PrintMetadata() override;
 
     TRestGeant4ParticleSourceCry();
     ~TRestGeant4ParticleSourceCry() {}

--- a/inc/TRestGeant4ParticleSourceCry.h
+++ b/inc/TRestGeant4ParticleSourceCry.h
@@ -12,27 +12,50 @@
 
 class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
 	private:
+		/// It defines if secondary neutrons will be produced by the generator
 		Int_t fReturnNeutrons = 1;
+		/// It defines if secondary protons will be produced by the generator
 		Int_t fReturnProtons = 1;
+		/// It defines if secondary photons will be produced by the generator
 		Int_t fReturnGammas = 1;
+		/// It defines if secondary gammas will be produced by the generator
 		Int_t fReturnElectrons = 1;
+		/// It defines if secondary electrons will be produced by the generator
 		Int_t fReturnPions = 1;
+		/// It defines if secondary pions will be produced by the generator
 		Int_t fReturnKaons = 1;
+		/// It defines if secondary muons will be produced by the generator
 		Int_t fReturnMuons = 1;
 
+		/// Showers with number of particles below this number will be truncated.
 		Int_t fNParticlesMin = 1;
+		/// Showers with number of particles above this number will be truncated.
 		Int_t fNParticlesMax = 1000000;
 
+		/// This is likely the X-coordinate where the box of generated particles is centered.
 		Double_t fXOffset = 0;
+		/// This is likely the Y-coordinate where the box of generated particles is centered.
 		Double_t fYOffset = 0;
+		/// This is likely the Z-coordinate where the box of generated particles is centered.
 		Double_t fZOffset = 0;
 
+		/// It will adjust the cosmic-ray distributions to the 11-year solar cycle.
 		std::string fDate = "7-1-2012";
 
+		/// The allowed range is -90 to 90. 0 defines the magnetic equator.
 		Double_t fLatitude = 90.0;;
+
+		/// Allowed values are 0, 2100 and 11300 m.
 		Double_t fAltitude = 0.0;;
 
+		/// The size of the box where the CRY generator produces particles (in m).
 		Double_t fSubBoxLength = 100.0;;
+
+		/// Seed used in random generator
+		Int_t fSeed = 0;  //<
+
+		/// Internal process random generator
+		TRandom3* fRandom = nullptr;  //!
 
    protected:
 #ifdef USE_CRY

--- a/inc/TRestGeant4ParticleSourceCry.h
+++ b/inc/TRestGeant4ParticleSourceCry.h
@@ -1,0 +1,30 @@
+#ifndef TRestParticleSourceCry_Class
+#define TRestParticleSourceCry_Class
+
+#include <iostream>
+
+#ifdef USE_CRY
+#include <CRYGenerator.h>
+#include <CRYSetup.h>
+#endif
+
+#include <TRestGeant4ParticleSource.h>
+
+class TRestGeant4ParticleSourceCry : public TRestGeant4ParticleSource {
+   protected:
+
+#ifdef USE_CRY
+	CRYGenerator* fCRYGenerator = nullptr;
+#endif
+
+   public:
+    void Update() override;
+    void InitFromConfigFile() override;
+    inline Int_t GetNumberOfParticles() const { return fParticles.size(); }
+    void PrintParticleSource() override;
+
+    TRestGeant4ParticleSourceCry();
+    ~TRestGeant4ParticleSourceCry() {  }
+    ClassDefOverride(TRestGeant4ParticleSourceCry, 1);
+};
+#endif

--- a/inc/TRestGeant4ParticleSourceDecay0.h
+++ b/inc/TRestGeant4ParticleSourceDecay0.h
@@ -27,7 +27,7 @@ class TRestGeant4ParticleSourceDecay0 : public TRestGeant4ParticleSource {
     void Update() override;
     void InitFromConfigFile() override;
     inline Int_t GetNumberOfParticles() const { return fParticles.size(); }
-    void PrintParticleSource() override;
+    void PrintMetadata() override;
 
     TRestGeant4ParticleSourceDecay0();
     ~TRestGeant4ParticleSourceDecay0() { delete fDecay0Model; }

--- a/inc/TRestGeant4PrimaryGeneratorInfo.h
+++ b/inc/TRestGeant4PrimaryGeneratorInfo.h
@@ -17,6 +17,7 @@ enum class SpatialGeneratorTypes {
     SURFACE,
     POINT,
     COSMIC,
+	CRY,
 };
 
 std::string SpatialGeneratorTypesToString(const SpatialGeneratorTypes&);

--- a/inc/TRestGeant4PrimaryGeneratorInfo.h
+++ b/inc/TRestGeant4PrimaryGeneratorInfo.h
@@ -17,7 +17,7 @@ enum class SpatialGeneratorTypes {
     SURFACE,
     POINT,
     COSMIC,
-    CRY,
+    SOURCE,
 };
 
 std::string SpatialGeneratorTypesToString(const SpatialGeneratorTypes&);

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -255,6 +255,9 @@
 /// x, y, nothing length the rectangle. "rectangle" shape works only for "surface"
 /// generator type. The initial direction of the rectangle is in parallel to x-y plane.
 ///
+/// * **source**: The positions of the particles will be defined by the particle source
+/// generator, see for example TRestGeant4ParticleSourceCry.
+///
 /// Rotation of the virtual body defined previously is also supported. We need to define
 /// parameter "rotationAxis" and "rotationAngle" to do this job. The TVector3 parameter
 /// "rotationAxis" is a virtual axis passing through the center of the virtual body,
@@ -289,7 +292,7 @@
 ///     <source use="Xe136bb0n.dat" />
 /// \endcode
 ///
-/// * the in-simulation decay0 generator package
+/// * the geant4lib encoded generators, such as decay0 or cry generators
 /// \code
 ///    // 2. decay0 package
 ///    <source use="decay0" particle="Xe136" decayMode="0vbb" daughterLevel="3" />

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1456,7 +1456,7 @@ void TRestGeant4Metadata::PrintMetadata() {
     RESTMetadata << "Number of generated events: " << GetNumberOfEvents() << RESTendl;
     fGeant4PrimaryGeneratorInfo.Print();
 
-    for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintParticleSource();
+    for (int i = 0; i < GetNumberOfSources(); i++) GetParticleSource(i)->PrintMetadata();
 
     RESTMetadata << " " << RESTendl;
     RESTMetadata << "   ++++++++++ Detector +++++++++++   " << RESTendl;

--- a/src/TRestGeant4Particle.cxx
+++ b/src/TRestGeant4Particle.cxx
@@ -1,20 +1,42 @@
-///_______________________________________________________________________________
-///_______________________________________________________________________________
-///_______________________________________________________________________________
-///
-///
-///             RESTSoft : Software for Rare Event Searches with TPCs
-///
-///             TRestGeant4Particle.cxx
-///
-///             Base class from which to inherit all other event classes in REST
-///
-///             jul 2015:   First concept
-///                 Created as part of the conceptualization of existing REST
-///                 software.
-///                 J. Galan
-///_______________________________________________________________________________
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
 
+//////////////////////////////////////////////////////////////////////////
+/// TRestGeant4Particle is just a container class to store particle properties
+///
+///
+///--------------------------------------------------------------------------
+///
+/// RESTsoft - Software for Rare Event Searches with TPCs
+///
+/// History of developments:
+///
+/// 2015-July: First concept and implementation
+/// \author     Javier Galan
+///
+/// \class TRestGeant4Particle
+///
+/// <hr>
+///
 #include "TRestGeant4Particle.h"
 
 using namespace std;
@@ -27,4 +49,30 @@ TRestGeant4Particle::TRestGeant4Particle() {
 
 TRestGeant4Particle::~TRestGeant4Particle() {
     // TRestGeant4Particle destructor
+}
+
+///////////////////////////////////////////////
+/// \brief A copy method
+///
+void TRestGeant4Particle::SetParticle(TRestGeant4Particle particle) {
+	fExcitationLevel = particle.GetExcitationLevel();
+	fParticleName = particle.GetParticleName();
+	fEnergy = particle.GetEnergy();
+	fDirection = particle.GetMomentumDirection();
+	fOrigin = particle.fOrigin;
+}
+
+///////////////////////////////////////////////
+/// \brief Prints on screen the details about the Geant4 simulation
+/// conditions, stored in TRestGeant4Metadata.
+///
+void TRestGeant4Particle::Print() const
+{
+	std::cout << "Particle name : " << GetParticleName() << std::endl;
+	std::cout << "Charge : " << GetParticleCharge() << std::endl;
+	std::cout << "Energy : " << GetEnergy() << " keV" << std::endl;
+	std::cout << "Excitation level : " << GetExcitationLevel() << std::endl;
+	std::cout << "X : " << GetOrigin().X() << "mm Y : " << GetOrigin().Y() << "mm Z : " << GetOrigin().Z() << "mm" << std::endl;
+	std::cout << "Px : " << GetMomentumDirection().X() << " Py : " << GetMomentumDirection().Y() << " Pz : " << GetMomentumDirection().Z() << std::endl;
+	std::cout << " ---------------------- " << std::endl;
 }

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -32,7 +32,7 @@ TRestGeant4ParticleSource::TRestGeant4ParticleSource() = default;
 
 TRestGeant4ParticleSource::~TRestGeant4ParticleSource() = default;
 
-void TRestGeant4ParticleSource::PrintParticleSource() {
+void TRestGeant4ParticleSource::PrintMetadata() {
     RESTMetadata << " " << RESTendl;
     if (GetParticleName() != "" && GetParticleName() != "NO_SUCH_PARA")
         RESTMetadata << "Particle Source Name: " << GetParticleName() << RESTendl;

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -97,13 +97,13 @@ TRestGeant4ParticleSource* TRestGeant4ParticleSource::instantiate(std::string mo
     } else {
         // use specific generator
         // naming convention: TRestGeant4ParticleSourceXXX
-        // currently supported generator: decay0
-        // in future we may add wrapper of generators: cry(for muon), pythia(for HEP), etc.
+        // currently supported generators: decay0, cry
+        // in future we may add wrapper of generators: pythia(for HEP), etc.
         model[0] = *REST_StringHelper::ToUpper(std::string(&model[0], 1)).c_str();
         TClass* c = TClass::GetClass(("TRestGeant4ParticleSource" + model).c_str());
         if (c)  // this means we have the package installed
         {
-            return (TRestGeant4ParticleSource*)c->New();
+            return (TRestGeant4ParticleSource*) c->New();
         } else {
             std::cout << "REST ERROR! generator wrapper \"" << ("TRestGeant4ParticleSource" + model)
                       << "\" not found!" << std::endl;

--- a/src/TRestGeant4ParticleSource.cxx
+++ b/src/TRestGeant4ParticleSource.cxx
@@ -97,7 +97,7 @@ TRestGeant4ParticleSource* TRestGeant4ParticleSource::instantiate(std::string mo
     } else {
         // use specific generator
         // naming convention: TRestGeant4ParticleSourceXXX
-        // currently supported generators: decay0, cry
+        // currently supported generators: decay0, source
         // in future we may add wrapper of generators: pythia(for HEP), etc.
         model[0] = *REST_StringHelper::ToUpper(std::string(&model[0], 1)).c_str();
         TClass* c = TClass::GetClass(("TRestGeant4ParticleSource" + model).c_str());

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -164,7 +164,18 @@ void TRestGeant4ParticleSourceCry::Update() {
 	}
 	std::cout << "-----" << std::endl;
 #else
-	cout << "TRestGeant4ParticleSourceCry - ERROR: restG4 was not linked to CRY libraries" << endl;
+	cout << "TRestGeant4ParticleSourceCry - ERROR: Geant4lib was not linked to CRY libraries" << endl;
+	cout << "  " << endl;
+	cout << "Please, compile REST using `cmake -DREST_CRY_PATH=/path/to/cry/installation/directory" << endl;
+	cout << "  " << endl;
+	cout << "By default CRY libraries will generate just the static library, but REST needs the shared library" << endl;
+	cout << "In order to generate the SHARED object from the STATIC libCRY.a object, execute the following command" << endl;
+	cout << "inside the CRY lib directory" << endl;
+	cout << "  " << endl;
+	cout << "```" << endl;
+	cout << "gcc -shared -o libCRY.so -Wl,--whole-archive libCRY.a -Wl,--no-whole-archive" << endl;
+	cout << "```" << endl;
+
 	exit(1);
 #endif
 

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -6,72 +6,83 @@ ClassImp(TRestGeant4ParticleSourceCry);
 
 TRestGeant4ParticleSourceCry::TRestGeant4ParticleSourceCry() {}
 
-void TRestGeant4ParticleSourceCry::PrintParticleSource() {
-    /*
-metadata << "---------------------------------------" << endl;
-if (!fParticleName.empty() && fParticleName != "NO_SUCH_PARA")
-    metadata << "Particle Source Name: " << fParticleName << endl;
-metadata << "Parent Nuclide: " << fParentName << endl;
-metadata << "Decay Mode: " << fDecayType << endl;
-metadata << "Daughter Level: " << fDaughterLevel << endl;
-metadata << "Seed: " << fSeed << endl;
-    */
+void TRestGeant4ParticleSourceCry::PrintMetadata() {
+
+	TRestGeant4ParticleSource::PrintMetadata();
+
+	RESTMetadata << "Return Neutrons : " << fReturnNeutrons << RESTendl;
+	RESTMetadata << "Return Protons : " << fReturnProtons << RESTendl;
+	RESTMetadata << "Return Gammas : " << fReturnGammas << RESTendl;
+	RESTMetadata << "Return Electrons : " << fReturnElectrons << RESTendl;
+	RESTMetadata << "Return Pions : " << fReturnPions << RESTendl;
+	RESTMetadata << "Return Kaons : " << fReturnKaons << RESTendl;
+	RESTMetadata << "Return Muons : " << fReturnMuons << RESTendl;
+	RESTMetadata << " ======= " << RESTendl;
+
+	RESTMetadata << "N particles min : " << fNParticlesMin << RESTendl;
+	RESTMetadata << "N particles max : " << fNParticlesMax << RESTendl;
+	RESTMetadata << " ======= " << RESTendl;
+
+	RESTMetadata << "X-offset : " << fXOffset << "m" << RESTendl;
+	RESTMetadata << "Y-offset : " << fYOffset << "m" << RESTendl;
+	RESTMetadata << "Z-offset : " << fZOffset << "m" << RESTendl;
+	RESTMetadata << "SubBoxLength : " << fSubBoxLength << "m" << RESTendl;
+	RESTMetadata << " ======= " << RESTendl;
+
+	RESTMetadata << "Date : " << fDate << RESTendl;
+	RESTMetadata << "Latitude : " << fLatitude << RESTendl;
+	RESTMetadata << "Altitude : " << fAltitude << RESTendl;
+	RESTMetadata << "----------------------" << RESTendl;
 }
 
 void TRestGeant4ParticleSourceCry::InitFromConfigFile() {
-    /*
-// unsigned int seed = (uintptr_t)this;
-// std::default_random_engine generator(seed);
-// prng = bxdecay0::std_random(generator);
-fParticleName = ((TRestMetadata*)this)->ClassName();
-fParentName = GetParameter("particle");
-fDecayType = GetParameter("decayMode");
-fDaughterLevel = StringToInteger(GetParameter("daughterLevel"));
-fSeed = StringToInteger(GetParameter("seed", "0"));
-if (fSeed != 0) {
-} else {
-    fSeed = (uintptr_t)this;
-}
-generator = new std::default_random_engine(fSeed);
-prng = new bxdecay0::std_random(*generator);
 
-fDecay0Model->set_decay_category(bxdecay0::decay0_generator::DECAY_CATEGORY_DBD);
+	fReturnNeutrons = StringToInteger( GetParameter( "returnNeutrons", "1" ) );
+	fReturnProtons = StringToInteger( GetParameter( "returnProtons", "1" ) );
+	fReturnGammas = StringToInteger( GetParameter( "returnGammas", "1" ) );
+	fReturnElectrons = StringToInteger( GetParameter( "returnElectrons", "1" ) );
+	fReturnPions = StringToInteger( GetParameter( "returnPions", "1" ) );
+	fReturnKaons = StringToInteger( GetParameter( "returnKaons", "1" ) );
+	fReturnMuons = StringToInteger( GetParameter( "returnMuons", "1" ) );
 
-if (fParentName != "Xe136") {
-    ferr << "Only Xe136 double beta decay is supported by restDecay0" << endl;
-    exit(1);
-}
-if (fDaughterLevel < 0 || fDaughterLevel > 3) {
-    ferr << "Supported Ba136 excitation level: 0, 1, 2, 3" << endl;
-    exit(1);
-}
+	fNParticlesMin = StringToInteger( GetParameter( "nParticlesMin", "1" ) );
+	fNParticlesMax = StringToInteger( GetParameter( "nParticlesMax", "1000000" ) );
 
-fDecay0Model->set_decay_isotope(fParentName);
+	fXOffset = StringToDouble( GetParameter( "xoffset", "0.0" ) );
+	fYOffset = StringToDouble( GetParameter( "yoffset", "0.0" ) );
+	fZOffset = StringToDouble( GetParameter( "zoffset", "0.0" ) );
+	fSubBoxLength = StringToDouble( GetParameter( "subBoxLength", "100.0" ) );
 
-fDecay0Model->set_decay_dbd_level(fDaughterLevel);
+	fDate = GetParameter( "date", "7\\1\\2012" );
+	fDate = REST_StringHelper::Replace( fDate, "\\", "-" );
+	fLatitude = StringToDouble( GetParameter( "latitude", "90.0" ) );
+	fAltitude = StringToDouble( GetParameter( "altitude", "0.0" ) );
 
-if (fDecayType == "2vbb") {
-    if (fDaughterLevel == 0 || fDaughterLevel == 3) {
-        fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_2NUBB_0_2N);
-    } else if (fDaughterLevel == 1 || fDaughterLevel == 2) {
-        fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_2NUBB_2_2N);
-    }
-} else if (fDecayType == "0vbb") {
-    if (fDaughterLevel == 0 || fDaughterLevel == 3) {
-        fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_0NUBB_MN_0_2N);
-    } else if (fDaughterLevel == 1 || fDaughterLevel == 2) {
-        fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_0NUBB_RHC_LAMBDA_2_2N);
-    }
-}
+	PrintMetadata();
 
-fDecay0Model->initialize(*prng);
-    */
+	std::string setupString = "";
+	setupString += "returnNeutrons " + IntegerToString(fReturnNeutrons);
+	setupString += " returnProtons " + IntegerToString(fReturnProtons);
+	setupString += " returnGammas " + IntegerToString(fReturnGammas);
+	setupString += " returnElectrons " + IntegerToString(fReturnElectrons);
+	setupString += " returnPions " + IntegerToString(fReturnPions);
+	setupString += " returnKaons " + IntegerToString(fReturnKaons);
+	setupString += " returnMuons " + IntegerToString(fReturnMuons);
+
+	setupString += " xoffset " + DoubleToString(fXOffset);
+	setupString += " yoffset " + DoubleToString(fYOffset);
+	setupString += " zoffset " + DoubleToString(fZOffset);
+	setupString += " subboxLength " + DoubleToString(fSubBoxLength);
+
+	setupString += " date " + fDate;
+	setupString += " latitude " + DoubleToString(fLatitude);
+	setupString += " altitude " + DoubleToString(fAltitude);
+
+	setupString += " nParticlesMin " + IntegerToString(fNParticlesMin);
+	setupString += " nParticlesMax " + IntegerToString(fNParticlesMax);
+
 
 #ifdef USE_CRY
-    /// Of course, we should be able to configure this inside InitFromConfigFile
-    std::string setupString = "returnNeutrons 1";
-    // std::string setupString = "returnNeutrons 1\nreturnProtons 1\nreturnGammas 1\ndate
-    // 7-1-2012\nlatitude 90.0\naltitude 0\nsubboxLength 100\n";
     CRYSetup* setup = new CRYSetup(setupString, CRY_DATA_PATH);
     fCRYGenerator = new CRYGenerator(setup);
 #endif
@@ -91,12 +102,10 @@ void TRestGeant4ParticleSourceCry::Update() {
     // std::cout << "-----" << std::endl;
 
     for (const auto& cryParticle : *ev) {
-		/*
-        std::cout << "id: " << cryParticle->id() << std::endl;
-        std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
-        std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
-        std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
-		*/
+        // std::cout << "id: " << cryParticle->id() << std::endl;
+        // std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
+        // std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
+        // std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
 
         TRestGeant4Particle particle;
 

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -87,10 +87,11 @@ void TRestGeant4ParticleSourceCry::Update() {
     ev->clear();
     fCRYGenerator->genEvent(ev);
 
-    std::cout << "CRY particles : " << ev->size() << std::endl;
-    std::cout << "-----" << std::endl;
+    // std::cout << "CRY particles : " << ev->size() << std::endl;
+    // std::cout << "-----" << std::endl;
 
     for (const auto& cryParticle : *ev) {
+		/*
         std::cout << "id: " << cryParticle->id() << std::endl;
 
         std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z()
@@ -98,6 +99,7 @@ void TRestGeant4ParticleSourceCry::Update() {
         std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w()
                   << std::endl;
         std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
+		*/
 
         TRestGeant4Particle particle;
 
@@ -162,7 +164,7 @@ void TRestGeant4ParticleSourceCry::Update() {
 
         AddParticle(particle);
     }
-    std::cout << "-----" << std::endl;
+    //std::cout << "-----" << std::endl;
 #else
     cout << "TRestGeant4ParticleSourceCry - ERROR: Geant4lib was not linked to CRY libraries" << endl;
     cout << "  " << endl;

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -1,0 +1,171 @@
+#include "TRestGeant4ParticleSourceCry.h"
+
+using namespace std;
+
+ClassImp(TRestGeant4ParticleSourceCry);
+
+TRestGeant4ParticleSourceCry::TRestGeant4ParticleSourceCry() {
+
+}
+
+void TRestGeant4ParticleSourceCry::PrintParticleSource() {
+	/*
+    metadata << "---------------------------------------" << endl;
+    if (!fParticleName.empty() && fParticleName != "NO_SUCH_PARA")
+        metadata << "Particle Source Name: " << fParticleName << endl;
+    metadata << "Parent Nuclide: " << fParentName << endl;
+    metadata << "Decay Mode: " << fDecayType << endl;
+    metadata << "Daughter Level: " << fDaughterLevel << endl;
+    metadata << "Seed: " << fSeed << endl;
+	*/
+}
+
+void TRestGeant4ParticleSourceCry::InitFromConfigFile() {
+	/*
+    // unsigned int seed = (uintptr_t)this;
+    // std::default_random_engine generator(seed);
+    // prng = bxdecay0::std_random(generator);
+    fParticleName = ((TRestMetadata*)this)->ClassName();
+    fParentName = GetParameter("particle");
+    fDecayType = GetParameter("decayMode");
+    fDaughterLevel = StringToInteger(GetParameter("daughterLevel"));
+    fSeed = StringToInteger(GetParameter("seed", "0"));
+    if (fSeed != 0) {
+    } else {
+        fSeed = (uintptr_t)this;
+    }
+    generator = new std::default_random_engine(fSeed);
+    prng = new bxdecay0::std_random(*generator);
+
+    fDecay0Model->set_decay_category(bxdecay0::decay0_generator::DECAY_CATEGORY_DBD);
+
+    if (fParentName != "Xe136") {
+        ferr << "Only Xe136 double beta decay is supported by restDecay0" << endl;
+        exit(1);
+    }
+    if (fDaughterLevel < 0 || fDaughterLevel > 3) {
+        ferr << "Supported Ba136 excitation level: 0, 1, 2, 3" << endl;
+        exit(1);
+    }
+
+    fDecay0Model->set_decay_isotope(fParentName);
+
+    fDecay0Model->set_decay_dbd_level(fDaughterLevel);
+
+    if (fDecayType == "2vbb") {
+        if (fDaughterLevel == 0 || fDaughterLevel == 3) {
+            fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_2NUBB_0_2N);
+        } else if (fDaughterLevel == 1 || fDaughterLevel == 2) {
+            fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_2NUBB_2_2N);
+        }
+    } else if (fDecayType == "0vbb") {
+        if (fDaughterLevel == 0 || fDaughterLevel == 3) {
+            fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_0NUBB_MN_0_2N);
+        } else if (fDaughterLevel == 1 || fDaughterLevel == 2) {
+            fDecay0Model->set_decay_dbd_mode(bxdecay0::DBDMODE_0NUBB_RHC_LAMBDA_2_2N);
+        }
+    }
+
+    fDecay0Model->initialize(*prng);
+	*/
+
+#ifdef USE_CRY
+	/// Of course, we should be able to configure this inside InitFromConfigFile
+	std::string setupString = "returnNeutrons 1";
+	//std::string setupString = "returnNeutrons 1\nreturnProtons 1\nreturnGammas 1\ndate 7-1-2012\nlatitude 90.0\naltitude 0\nsubboxLength 100\n";
+	CRYSetup* setup = new CRYSetup(setupString, CRY_DATA_PATH);
+	fCRYGenerator = new CRYGenerator(setup);
+#endif
+
+    Update();
+}
+
+void TRestGeant4ParticleSourceCry::Update() {
+	RemoveParticles();
+
+#ifdef USE_CRY
+	std::vector<CRYParticle*>* ev = new std::vector<CRYParticle*>;
+	ev->clear();
+	fCRYGenerator->genEvent(ev);
+
+	std::cout << "CRY particles : " << ev->size() << std::endl;
+	std::cout << "-----" << std::endl;
+
+	for(const auto &cryParticle : *ev )
+	{
+		std::cout << "id: " << cryParticle->id() << std::endl;
+
+		std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
+		std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
+		std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
+
+		TRestGeant4Particle particle;
+
+		/// Particle charge
+		particle.SetParticleCharge(cryParticle->charge());
+		particle.SetExcitationLevel(0);
+
+		/// Particle position
+		TVector3 position( cryParticle->x(), cryParticle->y(), cryParticle->z() );
+		particle.SetOrigin( position );
+
+		/// Momentum direction
+		TVector3 momDirection(cryParticle->u(), cryParticle->v(), cryParticle->w());
+		momDirection = momDirection.Unit();
+		particle.SetDirection(momDirection);
+
+		/// Kinetic energy
+		particle.SetEnergy(1000. * cryParticle->ke()); // In keV (default REST units)
+
+		/*
+		 * 0 : Neutron
+		 * 1 : Proton
+		 * 2 : Pion
+		 * 3 : Kaon
+		 * 4 : Muon
+		 * 5 : Electron
+		 * 6 : Gamma
+		 */
+
+		int id = cryParticle->id();
+		if (id == 0) particle.SetParticleName("neutron");
+		if (id == 1) particle.SetParticleName("proton");
+		if (id == 2) {
+			if( cryParticle->charge() > 0 )
+				particle.SetParticleName("pi+");
+			else if( cryParticle->charge() == 0 )
+				particle.SetParticleName("pi0");
+			else if( cryParticle->charge() < 0 )
+				particle.SetParticleName("pi-");
+		}
+		if (id == 3) {
+			if( cryParticle->charge() > 0 )
+				particle.SetParticleName("kaon+");
+			else if( cryParticle->charge() == 0 )
+				particle.SetParticleName("kaon0");
+			else if( cryParticle->charge() < 0 )
+				particle.SetParticleName("kaon-");
+		}
+		if (id == 4) {
+			if( cryParticle->charge() > 0 )
+				particle.SetParticleName("mu+");
+			else if( cryParticle->charge() < 0 )
+				particle.SetParticleName("mu-");
+		}
+		if (id == 5) {
+			if( cryParticle->charge() > 0 )
+				particle.SetParticleName("e+");
+			else if( cryParticle->charge() < 0 )
+				particle.SetParticleName("e-");
+		}
+		if (id == 6) particle.SetParticleName("gamma");
+
+		AddParticle(particle);
+	}
+	std::cout << "-----" << std::endl;
+#else
+	cout << "TRestGeant4ParticleSourceCry - ERROR: restG4 was not linked to CRY libraries" << endl;
+	exit(1);
+#endif
+
+}

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -93,11 +93,8 @@ void TRestGeant4ParticleSourceCry::Update() {
     for (const auto& cryParticle : *ev) {
 		/*
         std::cout << "id: " << cryParticle->id() << std::endl;
-
-        std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z()
-                  << std::endl;
-        std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w()
-                  << std::endl;
+        std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
+        std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
         std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
 		*/
 
@@ -109,7 +106,7 @@ void TRestGeant4ParticleSourceCry::Update() {
 
         /// Particle position
         TVector3 position(cryParticle->x(), cryParticle->y(), cryParticle->z());
-        particle.SetOrigin(position);
+        particle.SetOrigin(1000. * position); // In mm (default REST units)
 
         /// Momentum direction
         TVector3 momDirection(cryParticle->u(), cryParticle->v(), cryParticle->w());

--- a/src/TRestGeant4ParticleSourceCry.cxx
+++ b/src/TRestGeant4ParticleSourceCry.cxx
@@ -6,6 +6,9 @@ ClassImp(TRestGeant4ParticleSourceCry);
 
 TRestGeant4ParticleSourceCry::TRestGeant4ParticleSourceCry() {}
 
+///////////////////////////////////////////////
+/// \brief It will print on screen the settings used for the CRY generator setup.
+///
 void TRestGeant4ParticleSourceCry::PrintMetadata() {
 
 	TRestGeant4ParticleSource::PrintMetadata();
@@ -35,6 +38,9 @@ void TRestGeant4ParticleSourceCry::PrintMetadata() {
 	RESTMetadata << "----------------------" << RESTendl;
 }
 
+///////////////////////////////////////////////
+/// \brief Initialization of TRestGeant4ParticleSourceCry members through a RML file
+///
 void TRestGeant4ParticleSourceCry::InitFromConfigFile() {
 
 	fReturnNeutrons = StringToInteger( GetParameter( "returnNeutrons", "1" ) );
@@ -90,6 +96,9 @@ void TRestGeant4ParticleSourceCry::InitFromConfigFile() {
     Update();
 }
 
+///////////////////////////////////////////////
+/// \brief It is used by restG4 PrimaryGeneratorAction to update the particle source
+///
 void TRestGeant4ParticleSourceCry::Update() {
     RemoveParticles();
 
@@ -102,10 +111,12 @@ void TRestGeant4ParticleSourceCry::Update() {
     // std::cout << "-----" << std::endl;
 
     for (const auto& cryParticle : *ev) {
-        // std::cout << "id: " << cryParticle->id() << std::endl;
-        // std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
-        // std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
-        // std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
+		/*
+        std::cout << "id: " << cryParticle->id() << std::endl;
+        std::cout << "x: " << cryParticle->x() << " y: " << cryParticle->y() << " z: " << cryParticle->z() << std::endl;
+        std::cout << "u: " << cryParticle->u() << " v: " << cryParticle->v() << " w: " << cryParticle->w() << std::endl;
+        std::cout << "charge: " << cryParticle->charge() << " energy: " << cryParticle->ke() << std::endl;
+		*/
 
         TRestGeant4Particle particle;
 

--- a/src/TRestGeant4ParticleSourceDecay0.cxx
+++ b/src/TRestGeant4ParticleSourceDecay0.cxx
@@ -9,14 +9,14 @@ TRestGeant4ParticleSourceDecay0::TRestGeant4ParticleSourceDecay0()
     fDecay0Model = new bxdecay0::decay0_generator();
 }
 
-void TRestGeant4ParticleSourceDecay0::PrintParticleSource() {
-    metadata << "---------------------------------------" << endl;
+void TRestGeant4ParticleSourceDecay0::PrintMetadata() {
+    RESTMetadata << "---------------------------------------" << RESTendl;
     if (!fParticleName.empty() && fParticleName != "NO_SUCH_PARA")
-        metadata << "Particle Source Name: " << fParticleName << endl;
-    metadata << "Parent Nuclide: " << fParentName << endl;
-    metadata << "Decay Mode: " << fDecayType << endl;
-    metadata << "Daughter Level: " << fDaughterLevel << endl;
-    metadata << "Seed: " << fSeed << endl;
+        RESTMetadata << "Particle Source Name: " << fParticleName << RESTendl;
+    RESTMetadata << "Parent Nuclide: " << fParentName << RESTendl;
+    RESTMetadata << "Decay Mode: " << fDecayType << RESTendl;
+    RESTMetadata << "Daughter Level: " << fDaughterLevel << RESTendl;
+    RESTMetadata << "Seed: " << fSeed << RESTendl;
 }
 
 void TRestGeant4ParticleSourceDecay0::InitFromConfigFile() {

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -28,6 +28,8 @@ string TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypesToString(const Spa
             return "Point";
         case SpatialGeneratorTypes::COSMIC:
             return "Cosmic";
+        case SpatialGeneratorTypes::CRY:
+            return "Cry";
     }
     cout << "TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypesToString - Error - Unknown "
             "SpatialGeneratorTypes"
@@ -51,6 +53,9 @@ SpatialGeneratorTypes TRestGeant4PrimaryGeneratorTypes::StringToSpatialGenerator
     } else if (TString(type).EqualTo(SpatialGeneratorTypesToString(SpatialGeneratorTypes::COSMIC),
                                      TString::ECaseCompare::kIgnoreCase)) {
         return SpatialGeneratorTypes::COSMIC;
+    } else if (TString(type).EqualTo(SpatialGeneratorTypesToString(SpatialGeneratorTypes::CRY),
+                                     TString::ECaseCompare::kIgnoreCase)) {
+        return SpatialGeneratorTypes::CRY;
     } else {
         cout << "TRestGeant4PrimaryGeneratorTypes::StringToSpatialGeneratorTypes - Error - Unknown "
                 "SpatialGeneratorTypes: "

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -28,8 +28,8 @@ string TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypesToString(const Spa
             return "Point";
         case SpatialGeneratorTypes::COSMIC:
             return "Cosmic";
-        case SpatialGeneratorTypes::CRY:
-            return "Cry";
+        case SpatialGeneratorTypes::SOURCE:
+            return "Source";
     }
     cout << "TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypesToString - Error - Unknown "
             "SpatialGeneratorTypes"
@@ -53,9 +53,9 @@ SpatialGeneratorTypes TRestGeant4PrimaryGeneratorTypes::StringToSpatialGenerator
     } else if (TString(type).EqualTo(SpatialGeneratorTypesToString(SpatialGeneratorTypes::COSMIC),
                                      TString::ECaseCompare::kIgnoreCase)) {
         return SpatialGeneratorTypes::COSMIC;
-    } else if (TString(type).EqualTo(SpatialGeneratorTypesToString(SpatialGeneratorTypes::CRY),
+    } else if (TString(type).EqualTo(SpatialGeneratorTypesToString(SpatialGeneratorTypes::SOURCE),
                                      TString::ECaseCompare::kIgnoreCase)) {
-        return SpatialGeneratorTypes::CRY;
+        return SpatialGeneratorTypes::SOURCE;
     } else {
         cout << "TRestGeant4PrimaryGeneratorTypes::StringToSpatialGeneratorTypes - Error - Unknown "
                 "SpatialGeneratorTypes: "


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Large: 419](https://badgen.net/badge/PR%20Size/Large%3A%20419/red) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jgalan_cry)](https://github.com/rest-for-physics/geant4lib/commits/jgalan_cry) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The following PR implements an interface to CRY generator that can be plugged to `restG4`. All the access to CRY libraries is inside the class `TRestGeant4ParticleSourceCry`, which has been inspired on `TRestGeant4ParticleSourceDecay0`.

The class allows to configure/setup the CRY generator and it implements a method to update the particles for each event.

This PR requires minor contributions to `restG4` and `framework` repositories. 

- Inside `restG4` we simply include an example to test the generator `CryGenerator.rml`, and we introduce minor modifications inside `PrimaryGeneratorAction` so that when we use `<generator type="cry" ... >` the position of the particle is fixed using the CRY generator positions. rest-for-physics/restG4#121.

- Inside the framework we need to add the library `CRY` inside `thisREST.sh` so that executables will be able to find the library path. rest-for-physics/framework#489

----

In order to link the CRY libraries to `libRestGeant4` we need to generate the **shared object** from the static library `libCRY.a`.

This can be done with the following command:

```
gcc -shared -o libCRY.so -Wl,--whole-archive libCRY.a -Wl,--no-whole-archive
```

---

Once we have generated the `libCRY.so` we need to compile REST with the new option.

```
cmake -DREST_G4=ON -DREST_CRY_PATH=/path/to/cry/main/directory/
```

And we can use the new example added to `restG4`.

```
cd source/packages/restG4/examples/12.Generators/
restG4 CryGenerator.rml
```

10 events will be generated in this example, stored in the output file `CryGenerator.root`. We can open to inspect:

```
restRoot CryGenerator.root
```

And access the new particle source generator metadata:

<img width="1072" alt="Screenshot 2023-11-05 at 19 19 09" src="https://github.com/rest-for-physics/geant4lib/assets/12447509/f4d166b5-a0ac-4233-b394-f429dc5b019d">

And check the generator events:

<img width="1014" alt="Screenshot 2023-11-05 at 19 20 31" src="https://github.com/rest-for-physics/geant4lib/assets/12447509/f6b934d6-cc72-46a0-b48d-40b99d9a6083">

In the previous image we can see how the CRY generator has produced an `electron` and a `neutron`.


The event header contains also the source position, but only the one for the first (or last) particle. This is redundant information, but incomplete, since we need to really look to the tracks to understand what are the particles produced by the generator. Perhaps it would be better to remove those fields from TRestGeant4Event? @lobis? 

I have seen that `TRestGeant4ParticleSource` defines `PrintParticleSource` but perhaps this should be migrated to `PrintMetadata`? @nkx111 

I let @Jaime-AA to play around and validate the generator.

I was surprised that when I define altitude = 2100m, the particle is still produced at `z=0`, I guess one needs to use `zoffset` so that the particles are generated at that altitude.