### PR TITLE
TRestGeant4PhysicsList added optical physics list

### DIFF
--- a/src/TRestGeant4PhysicsLists.cxx
+++ b/src/TRestGeant4PhysicsLists.cxx
@@ -134,7 +134,7 @@ Bool_t TRestGeant4PhysicsLists::PhysicsListExists(const TString& physicsListName
                                             "G4HadronPhysicsQGSP_BIC_HP",
                                             "G4NeutronTrackingCut",
                                             "G4EmExtraPhysics",
-											"G4OpticalPhysics"};
+                                            "G4OpticalPhysics"};
 
     return validPhysicsLists.count(physicsListName) > 0;
 }


### PR DESCRIPTION
![mariajmz](https://badgen.net/badge/PR%20submitted%20by%3A/mariajmz/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=mariajmz_optical)](https://github.com/rest-for-physics/geant4lib/commits/mariajmz_optical) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I add "G4OpticalPhysics" to TRestGeant4PhysicsLists::PhysicsListExists. 
This PR is related to restG4 PR [https://github.com/rest-for-physics/restG4/pull/124](https://github.com/rest-for-physics/restG4/pull/124)
