### PR TITLE
Give warning instead of error on quenching process when volume not matched

### DIFF
--- a/src/TRestGeant4QuenchingProcess.cxx
+++ b/src/TRestGeant4QuenchingProcess.cxx
@@ -156,8 +156,8 @@ void TRestGeant4QuenchingProcess::InitProcess() {
         }
 
         if (physicalVolumes.empty()) {
-            cerr << "TRestGeant4QuenchingProcess: No volume found matching expression " << userVolume << endl;
-            exit(1);
+            RESTWarning << "TRestGeant4QuenchingProcess: No volume found matching expression: " << userVolume
+                        << RESTendl;
         }
 
         for (const auto& physicalVolume : physicalVolumes) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-quenching-warning)](https://github.com/rest-for-physics/geant4lib/commits/lobis-quenching-warning) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

