### PR TITLE
Identify events directly from generator

### DIFF
--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -511,8 +511,7 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     string subEventPrimaryParticleName;
     if (fOutputG4Event->GetSubID() != 0) {
         subEventPrimaryParticleName = fOutputG4Event->GetSubEventPrimaryEventParticleName();
-    }
-    else{
+    } else {
         subEventPrimaryParticleName = "generator";
     }
     SetObservableValue("subEventPrimaryParticleName", subEventPrimaryParticleName);

--- a/src/TRestGeant4AnalysisProcess.cxx
+++ b/src/TRestGeant4AnalysisProcess.cxx
@@ -512,6 +512,9 @@ TRestEvent* TRestGeant4AnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     if (fOutputG4Event->GetSubID() != 0) {
         subEventPrimaryParticleName = fOutputG4Event->GetSubEventPrimaryEventParticleName();
     }
+    else{
+        subEventPrimaryParticleName = "generator";
+    }
     SetObservableValue("subEventPrimaryParticleName", subEventPrimaryParticleName);
 
     TVector3 primaryDirection(xDirection, yDirection, zDirection);


### PR DESCRIPTION
![DavidDiezIb](https://badgen.net/badge/PR%20submitted%20by%3A/DavidDiezIb/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=DavidDiezIb-Identify_subEvents_from_generator)](https://github.com/rest-for-physics/geant4lib/commits/DavidDiezIb-Identify_subEvents_from_generator) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Events from generator appear in `subEventPrimaryParticlename ` observable as empty category. Now they will be identified as coming from initial generator, so no secondary emission.