### PR TITLE
Add option to stop decay chain at any given isotope

### DIFF
--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -213,8 +213,14 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// \brief Returns true in case full decay chain simulation is enabled.
     inline Bool_t isFullChainActivated() const { return fFullChain; }
 
-    /// \brief Returns the value of the maximum Geant4 step size in mm for the
-    /// target volume.
+    /// \brief Returns the isotopes that will stop the full chain decay simulation.
+    inline std::set<std::string> GetFullChainStopIsotopes() const { return fFullChainStopIsotopes; }
+
+    inline Bool_t IsIsotopeFullChainStop(const std::string& isotope) const {
+        return fFullChainStopIsotopes.count(isotope) > 0;
+    }
+
+    /// \brief Returns the value of the maximum Geant4 step size in mm for the target volume.
     inline Double_t GetMaxTargetStepSize() const { return fMaxTargetStepSize; }
 
     /// \brief Returns the time gap, in us, required to consider a Geant4 hit as a

--- a/inc/TRestGeant4Metadata.h
+++ b/inc/TRestGeant4Metadata.h
@@ -117,6 +117,9 @@ class TRestGeant4Metadata : public TRestMetadata {
     /// (fFullChain=true), or just a single decay (fFullChain=false).
     Bool_t fFullChain = true;
 
+    /// \brief If defined, it will stop the full chain decay simulation when one of these isotope appears.
+    std::set<std::string> fFullChainStopIsotopes;
+
     /// \brief The volume that serves as trigger for data storage. Only events that
     /// deposit a non-zero energy on this volume will be registered.
     std::vector<TString> fSensitiveVolumes;
@@ -242,23 +245,23 @@ class TRestGeant4Metadata : public TRestMetadata {
     inline void SetFullChain(Bool_t fullChain) { fFullChain = fullChain; }
 
     /// It sets the location of the geometry files
-    inline void SetGeometryPath(std::string path) { fGeometryPath = path; }
+    inline void SetGeometryPath(const std::string& path) { fGeometryPath = path; }
 
     /// It sets the main filename to be used for the GDML geometry
-    inline void SetGdmlFilename(std::string gdmlFile) { fGdmlFilename = gdmlFile; }
+    inline void SetGdmlFilename(const std::string& gdmlFile) { fGdmlFilename = gdmlFile; }
 
     /// Returns the reference provided at the GDML file header
-    inline void SetGdmlReference(std::string reference) { fGdmlReference = reference; }
+    inline void SetGdmlReference(const std::string& reference) { fGdmlReference = reference; }
 
     /// Returns the reference provided at the materials file header
-    inline void SetMaterialsReference(std::string reference) { fMaterialsReference = reference; }
+    inline void SetMaterialsReference(const std::string& reference) { fMaterialsReference = reference; }
 
     /// Returns the number of events to be simulated.
     inline Long64_t GetNumberOfEvents() const { return fNEvents; }
 
     inline Long64_t GetNumberOfRequestedEntries() const { return fNRequestedEntries; }
 
-    inline Int_t GetSimulationMaxTimeSeconds() const { return fSimulationMaxTimeSeconds; }
+    inline Double_t GetSimulationMaxTimeSeconds() const { return fSimulationMaxTimeSeconds; }
 
     inline Double_t GetSimulationTime() const { return fSimulationTime; }
 
@@ -398,7 +401,7 @@ class TRestGeant4Metadata : public TRestMetadata {
     TRestGeant4Metadata(const TRestGeant4Metadata& metadata);
     TRestGeant4Metadata& operator=(const TRestGeant4Metadata& metadata);
 
-    ClassDefOverride(TRestGeant4Metadata, 17);
+    ClassDefOverride(TRestGeant4Metadata, 18);
 
     // Allow modification of otherwise inaccessible / immutable members that shouldn't be modified by the user
     friend class SteppingAction;

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1104,7 +1104,7 @@ void TRestGeant4Metadata::ReadParticleSource(TRestGeant4ParticleSource* source, 
         SetFullChain(true);
     }
 
-    TString fullChainStopIsotopesString = GetParameter("fullChainStopIsotopes", sourceDefinition, "");
+    const TString fullChainStopIsotopesString = GetParameter("fullChainStopIsotopes", sourceDefinition, "");
     if (fullChainStopIsotopesString != "") {
         TObjArray* fullChainStopIsotopesArray = fullChainStopIsotopesString.Tokenize(",");
         for (int i = 0; i < fullChainStopIsotopesArray->GetEntries(); i++) {

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -219,7 +219,7 @@
 /// \endcode
 ///
 /// * **cosmic**: This is a special type of generator that is used to simulate cosmic particles.
-/// It takes no parameters. It uses the world size to produce an homogeneous cosmic ray flux (according to
+/// It takes no parameters. It uses the world size to produce an accurate cosmic ray flux (according to
 /// energy and angular distribution, which can be correlated) in the whole world volume. It is recommended to
 /// use this instead of other approaches such as an infinite plane above as this generator will be
 /// significantly more efficient since all particles are directed roughly towards the detector.
@@ -736,6 +736,7 @@
 
 #include <TAxis.h>
 #include <TGeoManager.h>
+#include <TObjString.h>
 #include <TRandom.h>
 #include <TRestGDMLParser.h>
 #include <TRestRun.h>
@@ -1101,6 +1102,15 @@ void TRestGeant4Metadata::ReadParticleSource(TRestGeant4ParticleSource* source, 
     SetFullChain(false);
     if (fullChain.EqualTo("on", TString::ECaseCompare::kIgnoreCase)) {
         SetFullChain(true);
+    }
+
+    TString fullChainStopIsotopesString = GetParameter("fullChainStopIsotopes", sourceDefinition, "");
+    if (fullChainStopIsotopesString != "") {
+        TObjArray* fullChainStopIsotopesArray = fullChainStopIsotopesString.Tokenize(",");
+        for (int i = 0; i < fullChainStopIsotopesArray->GetEntries(); i++) {
+            TString isotope = ((TObjString*)fullChainStopIsotopesArray->At(i))->String();
+            fFullChainStopIsotopes.insert(isotope.Data());
+        }
     }
 
     // Angular distribution parameters


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 28](https://badgen.net/badge/PR%20Size/Ok%3A%2028/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=decay-stop)](https://github.com/rest-for-physics/geant4lib/commits/decay-stop) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- https://github.com/rest-for-physics/restG4/pull/132

The option `fullChainStopIsotopes` can optionally be defined in the same line as `fullChainDecay` with a list of comma-separated isotopes.