### PR TITLE
Ability to select energy range in cosmic generator

### DIFF
--- a/inc/TRestGeant4ParticleSourceCosmics.h
+++ b/inc/TRestGeant4ParticleSourceCosmics.h
@@ -36,12 +36,7 @@ class TRestGeant4ParticleSourceCosmics : public TRestGeant4ParticleSource {
     std::map<std::string, TH2D*> GetHistogramsTransformed() const { return fHistogramsTransformed; }
     std::set<std::string> GetParticleNames() const { return fParticleNames; }
 
-    double GetEnergyRangeScalingFactor() const {
-        if (fCounterEnergyTotal == 0) {
-            return 1;
-        }
-        return fCounterEnergyAccepted / fCounterEnergyTotal;
-    }
+    double GetEnergyRangeScalingFactor() const;
 
     ClassDefOverride(TRestGeant4ParticleSourceCosmics, 3);
 };

--- a/inc/TRestGeant4ParticleSourceCosmics.h
+++ b/inc/TRestGeant4ParticleSourceCosmics.h
@@ -11,6 +11,10 @@ class TRestGeant4ParticleSourceCosmics : public TRestGeant4ParticleSource {
     std::set<std::string> fParticleNames;
     std::string fFilename;
     std::map<std::string, double> fParticleWeights;
+    std::pair<double, double> fEnergyRange = {0, 0};
+
+    unsigned long long fCounterEnergyTotal = 0;
+    unsigned long long fCounterEnergyAccepted = 0;
 
     std::map<std::string, TH2D*> fHistograms;
     std::map<std::string, TH2D*> fHistogramsTransformed;
@@ -32,7 +36,14 @@ class TRestGeant4ParticleSourceCosmics : public TRestGeant4ParticleSource {
     std::map<std::string, TH2D*> GetHistogramsTransformed() const { return fHistogramsTransformed; }
     std::set<std::string> GetParticleNames() const { return fParticleNames; }
 
-    ClassDefOverride(TRestGeant4ParticleSourceCosmics, 2);
+    double GetEnergyRangeScalingFactor() const {
+        if (fCounterEnergyTotal == 0) {
+            return 1;
+        }
+        return fCounterEnergyAccepted / fCounterEnergyTotal;
+    }
+
+    ClassDefOverride(TRestGeant4ParticleSourceCosmics, 3);
 };
 
 #endif  // REST_TRESTGEANT4PARTICLESOURCECOSMICS_H

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -982,14 +982,10 @@ Double_t TRestGeant4Metadata::GetCosmicIntensityInCountsPerSecond() const {
 }
 
 Double_t TRestGeant4Metadata::GetEquivalentSimulatedTime() const {
-    const auto countsPerSecond = GetCosmicIntensityInCountsPerSecond();
-    const auto seconds = double(fNEvents) / countsPerSecond;
-
-    double scalingFactor = 1.0;
-
     const auto type = ToLower(fGeant4PrimaryGeneratorInfo.GetSpatialGeneratorType());
     const auto shape = ToLower(fGeant4PrimaryGeneratorInfo.GetSpatialGeneratorShape());
 
+    double scalingFactor = 1.0;
     if (type == "cosmic") {
         // get the cosmic generator
         auto cosmicSource = dynamic_cast<TRestGeant4ParticleSourceCosmics*>(GetParticleSource());
@@ -1001,7 +997,11 @@ Double_t TRestGeant4Metadata::GetEquivalentSimulatedTime() const {
                                                           // vs full range of the hist (is 1 if full range)
     }
 
-    return seconds * scalingFactor;
+    // counts per seconds should be reduced proportionally to the range we are sampling
+    const auto countsPerSecond = GetCosmicIntensityInCountsPerSecond() * scalingFactor;
+    const auto seconds = double(fNEvents) / countsPerSecond;
+
+    return seconds;
 }
 
 void TRestGeant4Metadata::ReadBiasing() {

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -983,18 +983,19 @@ Double_t TRestGeant4Metadata::GetCosmicIntensityInCountsPerSecond() const {
 
 Double_t TRestGeant4Metadata::GetEquivalentSimulatedTime() const {
     const auto type = ToLower(fGeant4PrimaryGeneratorInfo.GetSpatialGeneratorType());
-    const auto shape = ToLower(fGeant4PrimaryGeneratorInfo.GetSpatialGeneratorShape());
 
     double scalingFactor = 1.0;
     if (type == "cosmic") {
         // get the cosmic generator
         auto cosmicSource = dynamic_cast<TRestGeant4ParticleSourceCosmics*>(GetParticleSource());
-        if (cosmicSource == nullptr) {
-            throw std::runtime_error("Cosmic source not found");
+        if (cosmicSource != nullptr) {
+            scalingFactor =
+                cosmicSource
+                    ->GetEnergyRangeScalingFactor();  // number less than 1, to account for energy range
+            if (scalingFactor < 0 || scalingFactor > 1) {
+                throw std::runtime_error("Energy range scaling factor must be between 0 and 1");
+            }
         }
-        scalingFactor =
-            cosmicSource->GetEnergyRangeScalingFactor();  // number less than 1, to account for energy range
-                                                          // vs full range of the hist (is 1 if full range)
     }
 
     // counts per seconds should be reduced proportionally to the range we are sampling

--- a/src/TRestGeant4ParticleSourceCosmics.cxx
+++ b/src/TRestGeant4ParticleSourceCosmics.cxx
@@ -180,5 +180,5 @@ double TRestGeant4ParticleSourceCosmics::GetEnergyRangeScalingFactor() const {
             "particles.");
     }
 
-    return fCounterEnergyAccepted / fCounterEnergyTotal;
+    return double(fCounterEnergyAccepted) / double(fCounterEnergyTotal);
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 53](https://badgen.net/badge/PR%20Size/Ok%3A%2053/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=cosmics-choose-energy)](https://github.com/rest-for-physics/geant4lib/commits/cosmics-choose-energy) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

```
<generator type="cosmic">
    <source use="Cosmics" direction="(0,-1,0)" filename="../cosmics.root"
            particles="neutron" energy="(1,10)MeV"/>
</generator>
```

Works to limit the range of the generator, the equivalent simulation time is adjusted accordingly. This works by continously sampling the full range until the energy lies in the selected range, then the ratio of accepted / total attempts is used to bias the simulation time. This is not the optimal approach but it is easy enough to implement (an especially to maintain) and it shouldn't be a problem since sampling the histogram is much faster than doing the radiation transport of an event (unless the energy range is extremely narrow, then this may become a bottleneck).