### PR TITLE
Formula for evaporation neutrons from U238

### DIFF
--- a/inc/TRestGeant4PrimaryGeneratorInfo.h
+++ b/inc/TRestGeant4PrimaryGeneratorInfo.h
@@ -48,11 +48,7 @@ enum class EnergyDistributionTypes {
 std::string EnergyDistributionTypesToString(const EnergyDistributionTypes&);
 EnergyDistributionTypes StringToEnergyDistributionTypes(const std::string&);
 
-enum class EnergyDistributionFormulas {
-    COSMIC_NEUTRONS,
-    COSMIC_GAMMAS,
-    FISSION_NEUTRONS_U238
-};
+enum class EnergyDistributionFormulas { COSMIC_NEUTRONS, COSMIC_GAMMAS, FISSION_NEUTRONS_U238 };
 
 std::string EnergyDistributionFormulasToString(const EnergyDistributionFormulas&);
 EnergyDistributionFormulas StringToEnergyDistributionFormulas(const std::string&);

--- a/inc/TRestGeant4PrimaryGeneratorInfo.h
+++ b/inc/TRestGeant4PrimaryGeneratorInfo.h
@@ -51,6 +51,7 @@ EnergyDistributionTypes StringToEnergyDistributionTypes(const std::string&);
 enum class EnergyDistributionFormulas {
     COSMIC_NEUTRONS,
     COSMIC_GAMMAS,
+    FISSION_NEUTRONS_U238
 };
 
 std::string EnergyDistributionFormulasToString(const EnergyDistributionFormulas&);

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -228,8 +228,8 @@ TF1 TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula(
             // Watt formula for U238. The spectrum parameters are from this reference
             // https://arxiv.org/pdf/hep-ex/0312050
             const char* title = "Watt formula: Neutrons from U238 fission";
-            auto distribution = TF1(title, "TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))",
-                                    0, 10000);  // keV
+            auto distribution =
+                TF1(title, "TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))", 0, 10000);  // keV
             distribution.SetNormalized(true);
             distribution.SetTitle(title);
             distribution.GetXaxis()->SetTitle("Energy (keV)");

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -174,6 +174,8 @@ string TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToString(
             return "CosmicNeutrons";
         case EnergyDistributionFormulas::COSMIC_GAMMAS:
             return "CosmicGammas";
+        case EnergyDistributionFormulas::FISSION_NEUTRONS_U238:
+            return "FissionNeutronsU238";
     }
     cout << "TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToString - Error - Unknown energy "
             "distribution formula"
@@ -190,6 +192,10 @@ EnergyDistributionFormulas TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistr
                    EnergyDistributionFormulasToString(EnergyDistributionFormulas::COSMIC_GAMMAS),
                    TString::ECaseCompare::kIgnoreCase)) {
         return EnergyDistributionFormulas::COSMIC_GAMMAS;
+    } else if (TString(type).EqualTo(
+                   EnergyDistributionFormulasToString(EnergyDistributionFormulas::FISSION_NEUTRONS_U238),
+                   TString::ECaseCompare::kIgnoreCase)){
+
     } else {
         cout << "TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistributionFormulas - Error - Unknown "
                 "energyDistributionFormulas: "
@@ -218,6 +224,17 @@ TF1 TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula(
         }
         case EnergyDistributionFormulas::COSMIC_GAMMAS:
             exit(1);
+        case EnergyDistributionFormulas::FISSION_NEUTRONS_U238: {
+            // Watt formula for U238. The spectrum parameters are from this reference https://arxiv.org/pdf/hep-ex/0312050
+            const char* title = "Watt formula: Neutrons from U238 fission";
+            auto distribution =
+                TF1(title,"TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))", 0.1, 10000); //keV
+            distribution.SetNormalized(true); 
+            distribution.SetTitle(title);
+            distribution.GetXaxis()->SetTitle("Energy (keV)");
+            return distribution;
+        }
+        
     }
     cout << "TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula - Error - Unknown "
             "energy distribution formula"

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -195,6 +195,7 @@ EnergyDistributionFormulas TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistr
     } else if (TString(type).EqualTo(
                    EnergyDistributionFormulasToString(EnergyDistributionFormulas::FISSION_NEUTRONS_U238),
                    TString::ECaseCompare::kIgnoreCase)) {
+        return EnergyDistributionFormulas::FISSION_NEUTRONS_U238;
     } else {
         cout << "TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistributionFormulas - Error - Unknown "
                 "energyDistributionFormulas: "

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -194,8 +194,7 @@ EnergyDistributionFormulas TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistr
         return EnergyDistributionFormulas::COSMIC_GAMMAS;
     } else if (TString(type).EqualTo(
                    EnergyDistributionFormulasToString(EnergyDistributionFormulas::FISSION_NEUTRONS_U238),
-                   TString::ECaseCompare::kIgnoreCase)){
-
+                   TString::ECaseCompare::kIgnoreCase)) {
     } else {
         cout << "TRestGeant4PrimaryGeneratorTypes::StringToEnergyDistributionFormulas - Error - Unknown "
                 "energyDistributionFormulas: "
@@ -225,16 +224,16 @@ TF1 TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula(
         case EnergyDistributionFormulas::COSMIC_GAMMAS:
             exit(1);
         case EnergyDistributionFormulas::FISSION_NEUTRONS_U238: {
-            // Watt formula for U238. The spectrum parameters are from this reference https://arxiv.org/pdf/hep-ex/0312050
+            // Watt formula for U238. The spectrum parameters are from this reference
+            // https://arxiv.org/pdf/hep-ex/0312050
             const char* title = "Watt formula: Neutrons from U238 fission";
-            auto distribution =
-                TF1(title,"TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))", 0.1, 10000); //keV
-            distribution.SetNormalized(true); 
+            auto distribution = TF1(title, "TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))",
+                                    0.1, 10000);  // keV
+            distribution.SetNormalized(true);
             distribution.SetTitle(title);
             distribution.GetXaxis()->SetTitle("Energy (keV)");
             return distribution;
         }
-        
     }
     cout << "TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula - Error - Unknown "
             "energy distribution formula"

--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -229,7 +229,7 @@ TF1 TRestGeant4PrimaryGeneratorTypes::EnergyDistributionFormulasToRootFormula(
             // https://arxiv.org/pdf/hep-ex/0312050
             const char* title = "Watt formula: Neutrons from U238 fission";
             auto distribution = TF1(title, "TMath::Exp(-x/712.4) * TMath::SinH(TMath::Sqrt(0.0056405*x))",
-                                    0.1, 10000);  // keV
+                                    0, 10000);  // keV
             distribution.SetNormalized(true);
             distribution.SetTitle(title);
             distribution.GetXaxis()->SetTitle("Energy (keV)");


### PR DESCRIPTION
![mariajmz](https://badgen.net/badge/PR%20submitted%20by%3A/mariajmz/blue) ![Ok: 18](https://badgen.net/badge/PR%20Size/Ok%3A%2018/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=mariajmz_wattformula)](https://github.com/rest-for-physics/geant4lib/commits/mariajmz_wattformula) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New formula added to simulate the Watt's spectrum for U238 fission neutrons. For the parameters of the Watt's formula I used the reference:
[https://arxiv.org/pdf/hep-ex/0312050](https://arxiv.org/pdf/hep-ex/0312050)

I have checked with a simulation of geantinos and this is the energy of the primaries simulated compared to the formula, in red:

![imagen](https://github.com/user-attachments/assets/b07f859e-432b-4a9d-a63e-43b908768214)

The original formula is in MeV units, I adjusted the parameters so the energy is in keV (to be consistent with the other examples):

a = 0.7124 MeV -> 712.4 keV
b = 5.6405 MeV^-1 -> 0.0056405 keV^-1

Usage in the `<generator>` section of the simulation RML: 
`<energy type="formula" name="FissionNeutronsU238" range="(Emin,Emax)keV"/>`