### PR TITLE
Add optional volume parameter to use alias observable name

### DIFF
--- a/inc/TRestGeant4AnalysisProcess.h
+++ b/inc/TRestGeant4AnalysisProcess.h
@@ -87,7 +87,7 @@ class TRestGeant4AnalysisProcess : public TRestEventProcess {
     void LoadDefaultConfig();
 
    protected:
-    // add here the members of your event process
+    std::map<std::string, std::string> GetAliasObservableNameToVolume();
 
    public:
     RESTValue GetInputEvent() const override { return fInputG4Event; }


### PR DESCRIPTION
![AlvaroEzq](https://img.shields.io/badge/PR_submitted_by%3A-AlvaroEzq-blue?logo=) ![Ok: 50](https://img.shields.io/badge/PR_Size-Ok%3A_50-green?logo=) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=aezq_aliasVolumeNames)](https://github.com/rest-for-physics/geant4lib/commits/aezq_aliasVolumeNames) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now that nested volumes are accepted in restG4, the volume names can be really long. To avoid the inconvenience of having very long observable names, we can now tell the volume for the obserfvable in a different parameter and set the observable name as any alias you want. For example, setting

```
<observable name="sensGasLeftVolumeEDep" value="ON" volume="shielding/outerGas/vesselassembly/gas/sensitiveGasLeft" description="Energy deposited in the sensitive gas left volume in keV" />
```
the observable name will be `sensGasLeftVolumeEDep`, and it will contain the energy deposited in the volume `shielding/outerGas/vesselassembly/gas/sensitiveGasLeft`

It would be nice if the description was updated automatically with the name of the volume used (to keep that information somwhere) but I don't find a easy way to do this. So I think is best to let the user be responsible for that.