### PR TITLE
Store rotation in world frame of physical volumes

### DIFF
--- a/inc/TRestGeant4GeometryInfo.h
+++ b/inc/TRestGeant4GeometryInfo.h
@@ -5,6 +5,7 @@
 #include <TRestStringOutput.h>
 #include <TString.h>
 #include <TVector3.h>
+#include <TRotation.h>
 
 #include <map>
 #include <set>
@@ -13,7 +14,7 @@
 class G4VPhysicalVolume;
 
 class TRestGeant4GeometryInfo {
-    ClassDef(TRestGeant4GeometryInfo, 4);
+    ClassDef(TRestGeant4GeometryInfo, 5);
 
    private:
     bool fIsAssembly = false;
@@ -67,6 +68,9 @@ class TRestGeant4GeometryInfo {
     /// Map of GDML physical volume name to its position in world coordinates
     std::map<TString, TVector3> fPhysicalToPositionInWorldMap;
 
+    /// Map of GDML physical volume name to its rotation in world coordinates
+    std::map<TString, TRotation> fPhysicalToRotationInWorldMap;
+
    public:
     inline TRestGeant4GeometryInfo() = default;
 
@@ -119,6 +123,11 @@ class TRestGeant4GeometryInfo {
     /// \brief Gets the position in world coordinates of a given physical volume.
     inline TVector3 GetPosition(const TString& volume) const {
         return fPhysicalToPositionInWorldMap.at(volume);
+    }
+
+    /// \brief Gets the rotation in world coordinates of a given physical volume.
+    inline TRotation GetRotation(const TString& volume) const {
+        return fPhysicalToRotationInWorldMap.at(volume);
     }
 
     inline bool IsAssembly() const { return fIsAssembly; }

--- a/inc/TRestGeant4GeometryInfo.h
+++ b/inc/TRestGeant4GeometryInfo.h
@@ -3,9 +3,9 @@
 #define REST_TRESTGEANT4GEOMETRYINFO_H
 
 #include <TRestStringOutput.h>
+#include <TRotation.h>
 #include <TString.h>
 #include <TVector3.h>
-#include <TRotation.h>
 
 #include <map>
 #include <set>

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -217,7 +217,8 @@
 ///
 /// * **gdml**: Bound the generator to a certain gdml component. No need to define size
 /// and position. Needs another "from" parameter. If the "from" parameter is defined,
-/// we can omit `shape="gdml"` parameter.
+/// we can omit `shape="gdml"` parameter. In the case that the gdml volume has daughters,
+/// the particles will be generated excluding the daughter volumes.
 /// \code
 ///     // We launch particles from random positions inside the vessel volume defined in our GDML geometry
 ///     <generator type="volume" from="vessel" > ... </generator>
@@ -543,9 +544,15 @@
 /// the GDML geometry. If an event did not produce an energy deposit in the
 /// sensitiveVolume, the event will not be stored at all. Therefore, the
 /// sensitive volume will serve as a trigger volume to decide when an event
-/// should be stored. For the moment we can only define a single sensitive
-/// volume, but it might be desirable to introduce boolean operations with
-/// different geometry volumes.
+/// should be stored. Multiple sensitive volumes can be defined by using
+/// different `<volume>` definitions with the parameter `sensitive="true"`.
+/// When multiple sensitive volumes are defined, the event will be stored
+/// if an energy deposit is produced in any of these sensitive volumes.
+/// You can also use a logical volume as sensitive volume, in this case
+/// all the physical volumes corresponding to that logical volume will be
+/// set as sensitive volumes. Furthermore, you can use regular expressions
+/// (at the parameter `name` of the `<volume>` definition) to define
+/// multiple sensitive volumes matching a certain pattern.
 ///
 /// We can define the energy range we are interested in by defining the
 /// parameter energyRange. The event will be written to disk only if the
@@ -629,8 +636,9 @@
 /// \endcode
 ///
 /// The option `removeUnwantedTracks` can optionally be enabled inside detector section:
-///
+/// \code
 /// <detector><removeUnwantedTracks enabled="true" keepZeroEnergyTracks="true"/></detector>
+/// \endcode
 ///
 /// This option will remove all tracks that do not deposit energy in any of the sensitive volumes or in any of
 /// the volumes marked as 'keepTracks' (for instance <volume name="veto" keepTracks="true" />).


### PR DESCRIPTION
![AlvaroEzq](https://img.shields.io/badge/PR_submitted_by%3A-AlvaroEzq-blue?logo=) ![Ok: 10](https://img.shields.io/badge/PR_Size-Ok%3A_10-green?logo=) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=aezq_differentiatePV)](https://github.com/rest-for-physics/geant4lib/commits/aezq_differentiatePV) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

To fix bug https://github.com/rest-for-physics/restG4/issues/143, the rotation (wrt world frame) of each physical volume must be stored to be used later in https://github.com/rest-for-physics/restG4.