### PR TITLE
Fix memory leak in merge macro

### DIFF
--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -123,6 +123,7 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
     mergeMetadata.Write();
     mergeRun->UpdateOutputFile();
     mergeRun->CloseFile();
+    delete mergeRun;
 
     // Open the file again to check the number of events
     TRestRun runCheck(outputFilename);


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=cris_fix_merge_macro_memory_leak)](https://github.com/rest-for-physics/geant4lib/commits/cris_fix_merge_macro_memory_leak) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

- Add missing `delete mergeRun` after `CloseFile()` in `REST_Geant4_MergeRestG4Files` macro
 - Without this, each merge operation leaks the entire `TRestRun` object
 - Together with the `TRestRun::CloseFile` fix (rest-for-physics/framework#562), this resolves the memory growth when merging a large number of files

Relates to rest-for-physics/framework#519

@rest-for-physics/geant4lib 