### PR TITLE
[codex] Document ParticleHP physics-list options

### DIFF
--- a/src/TRestGeant4PhysicsLists.cxx
+++ b/src/TRestGeant4PhysicsLists.cxx
@@ -14,6 +14,21 @@
 ///                     in a REST-Geant4 simulation.
 ///
 ///                 Javier Galan
+///
+///             ParticleHP options for neutron simulations can be passed through
+///             the HP hadronic physics-list entries. For example:
+///
+///             <physicsList name="G4HadronPhysicsQGSP_BIC_HP">
+///                 <option name="usePhotoEvaporation" value="true"/>
+///                 <option name="skipMissingIsotopes" value="true"/>
+///             </physicsList>
+///
+///             These options are translated by restG4 into the corresponding
+///             G4ParticleHPManager settings before the hadronic processes are
+///             constructed. They are useful for validation studies of
+///             neutron-capture gamma cascades, where the default ParticleHP
+///             capture final states and the PhotonEvaporation de-excitation
+///             model should be compared explicitly.
 ///_______________________________________________________________________________
 
 #include "TRestGeant4PhysicsLists.h"


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 15](https://badgen.net/badge/PR%20Size/Ok%3A%2015/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=codex/particlehp-options-doc)](https://github.com/rest-for-physics/geant4lib/commits/codex/particlehp-options-doc) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

- document ParticleHP options in `TRestGeant4PhysicsLists`
- show the RML syntax for enabling PhotonEvaporation and strict missing-isotope handling on HP hadronic physics-list entries
- clarify that restG4 applies these through `G4ParticleHPManager` before hadronic process construction

## Why

The neutron-capture gamma validation workflow now relies on explicit RML-configurable ParticleHP settings. This comment gives users a discoverable example in the physics-list metadata implementation.

## Validation

- `git diff --check`
- `cmake --build /Users/lobis/git/iaxo/framework/cmake-build-rest-macos --target RestGeant4 -j4` 