### PR TITLE
[codex] Fix Guan cosmic muon normalization

### DIFF
--- a/src/TRestGeant4PrimaryGeneratorInfo.cxx
+++ b/src/TRestGeant4PrimaryGeneratorInfo.cxx
@@ -460,11 +460,12 @@ TF2 TRestGeant4PrimaryGeneratorTypes::EnergyAndAngularDistributionFormulasToRoot
             // Guan formula from https://arxiv.org/pdf/1509.06176.pdf
             // muon rest mass is 105.7 MeV
             // energy in keV
-            // already integrated in phi (*2pi): formula returns (counts/cm2/s)/keV/rad(theta)
+            // Original Guan formula is differential in solid angle. The final factor integrates over
+            // azimuth and converts dOmega to 2*pi*sin(theta)*dtheta, so do not add another 2*pi here.
             const char* title = "Cosmic Muons Energy and Angular";
             auto f =
                 TF2(title,
-                    "2*TMath::Pi()*1E-6*0.14*TMath::Power(x*1E-6*(1.+3.64/"
+                    "1E-6*0.14*TMath::Power(x*1E-6*(1.+3.64/"
                     "(x*1E-6*TMath::Power(TMath::Power((TMath::Power(TMath::Cos(y),2)+0.0105212-0.068287*"
                     "TMath::Power(TMath::Cos(y),0.958633)+0.0407253*TMath::Power(TMath::Cos(y),0.817285)"
                     ")/(0.982960),0.5),1.29))),-2.7)*(1./"


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=codex/fix-guan-muon-2pi)](https://github.com/rest-for-physics/geant4lib/commits/codex/fix-guan-muon-2pi) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

This removes an extra azimuth factor from the analytic Guan cosmic-muon source formula used by `CosmicMuons`.

The formula already ends with the correct solid-angle conversion and azimuth integration,

```text
2*pi*sin(theta) dtheta
```

so the leading `2*pi` multiplied the generated muon rate by another factor of about `2*pi`.

## Impact

The generated muon kinematics are unchanged, but the REST source normalization and equivalent simulated time metadata are corrected. Existing productions made with the previous formula have equivalent times that are too small by approximately `2*pi`, and should be rescaled if used for rate estimates.

## Validation

- Rebuilt and installed the patched REST/Geant4 library on `naf-iaxo`.
- Confirmed the installed `libRestGeant4.so` contains the corrected formula without the leading `2*pi`.
- Cross-checked the integrated Guan flux against the expected sea-level value: `1.72e-2 cm^-2 s^-1`, or about `1.03 cm^-2 min^-1`. 