### PR TITLE
Validate restG4 merge metadata

### DIFF
--- a/inc/TRestGeant4PhysicsInfo.h
+++ b/inc/TRestGeant4PhysicsInfo.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <string>
 #include <vector>
 
 class G4VProcess;
@@ -35,6 +36,7 @@ class TRestGeant4PhysicsInfo {
 
     TString GetProcessType(const TString& processName) const;
     std::set<TString> GetAllProcessTypes() const;
+    bool Merge(const TRestGeant4PhysicsInfo& other, std::string* conflictReason = nullptr);
 
    public:
     inline TRestGeant4PhysicsInfo() = default;

--- a/inc/TRestGeant4PhysicsLists.h
+++ b/inc/TRestGeant4PhysicsLists.h
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <vector>
 
 class TRestGeant4PhysicsLists : public TRestMetadata {
@@ -39,13 +40,13 @@ class TRestGeant4PhysicsLists : public TRestMetadata {
     std::vector<TString> fPhysicsLists;
     std::vector<TString> fPhysicsListOptions;
 
-    Double_t fCutForElectron;
-    Double_t fCutForGamma;
-    Double_t fCutForPositron;
-    Double_t fCutForMuon;
-    Double_t fCutForNeutron;
-    Double_t fMinEnergyRangeProductionCuts;
-    Double_t fMaxEnergyRangeProductionCuts;
+    Double_t fCutForElectron = 1;
+    Double_t fCutForGamma = 0.01;
+    Double_t fCutForPositron = 1;
+    Double_t fCutForMuon = 1;
+    Double_t fCutForNeutron = 1;
+    Double_t fMinEnergyRangeProductionCuts = 1;
+    Double_t fMaxEnergyRangeProductionCuts = 1e6;
 
     std::vector<std::string> fIonLimitStepList;
 
@@ -60,9 +61,13 @@ class TRestGeant4PhysicsLists : public TRestMetadata {
 
     inline Double_t GetMinimumEnergyProductionCuts() const { return fMinEnergyRangeProductionCuts; }
     inline Double_t GetMaximumEnergyProductionCuts() const { return fMaxEnergyRangeProductionCuts; }
+    inline const std::vector<TString>& GetPhysicsLists() const { return fPhysicsLists; }
+    inline const std::vector<TString>& GetPhysicsListOptions() const { return fPhysicsListOptions; }
 
     Int_t FindPhysicsList(const TString& physicsListName) const;
     Bool_t PhysicsListExists(const TString& physicsListName) const;
+    Bool_t IsEquivalentTo(const TRestGeant4PhysicsLists& other,
+                          std::string* difference = nullptr) const;
 
     TString GetPhysicsListOptionValue(const TString& physicsListName, const TString& option,
                                       const TString& defaultValue = "NotDefined") const;

--- a/inc/TRestGeant4PhysicsLists.h
+++ b/inc/TRestGeant4PhysicsLists.h
@@ -66,8 +66,7 @@ class TRestGeant4PhysicsLists : public TRestMetadata {
 
     Int_t FindPhysicsList(const TString& physicsListName) const;
     Bool_t PhysicsListExists(const TString& physicsListName) const;
-    Bool_t IsEquivalentTo(const TRestGeant4PhysicsLists& other,
-                          std::string* difference = nullptr) const;
+    Bool_t IsEquivalentTo(const TRestGeant4PhysicsLists& other, std::string* difference = nullptr) const;
 
     TString GetPhysicsListOptionValue(const TString& physicsListName, const TString& option,
                                       const TString& defaultValue = "NotDefined") const;

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -196,8 +196,8 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
     }
     string physicsListsDifference;
     if (!mergedPhysicsLists->IsEquivalentTo(*mergePhysicsLists, &physicsListsDifference)) {
-        cerr << "ERROR: merged output did not preserve TRestGeant4PhysicsLists: "
-             << physicsListsDifference << endl;
+        cerr << "ERROR: merged output did not preserve TRestGeant4PhysicsLists: " << physicsListsDifference
+             << endl;
         exit(1);
     }
     cout << "Number of events in the output file: " << runCheck.GetEntries() << " matches internal count"

--- a/macros/REST_Geant4_MergeRestG4Files.C
+++ b/macros/REST_Geant4_MergeRestG4Files.C
@@ -1,8 +1,10 @@
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "TRestGeant4Event.h"
 #include "TRestGeant4Metadata.h"
+#include "TRestGeant4PhysicsLists.h"
 #include "TRestTask.h"
 
 #ifndef RestTask_Geant4_MergeRestG4Files
@@ -27,6 +29,27 @@
 
 using namespace std;
 
+namespace {
+void ValidateInputCompatibility(const string& inputFilename, const TRestGeant4Metadata& referenceMetadata,
+                                const TRestGeant4PhysicsLists& referencePhysicsLists,
+                                const TRestGeant4Metadata& metadata,
+                                const TRestGeant4PhysicsLists& physicsLists) {
+    if (referenceMetadata.GetGeant4Version() != metadata.GetGeant4Version()) {
+        cerr << "ERROR: input file '" << inputFilename << "' was produced with Geant4 version '"
+             << metadata.GetGeant4Version() << "', but the first input file used '"
+             << referenceMetadata.GetGeant4Version() << "'" << endl;
+        exit(1);
+    }
+
+    string physicsListsDifference;
+    if (!referencePhysicsLists.IsEquivalentTo(physicsLists, &physicsListsDifference)) {
+        cerr << "ERROR: input file '" << inputFilename
+             << "' uses incompatible TRestGeant4PhysicsLists: " << physicsListsDifference << endl;
+        exit(1);
+    }
+}
+}  // namespace
+
 void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputFilesDirectory) {
     // TODO: use glob pattern instead of directory. Already tried this but conflicts with TRestTask...
 
@@ -48,7 +71,8 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
     }
 
     // open the first file
-    TRestGeant4Metadata mergeMetadata;
+    unique_ptr<TRestGeant4Metadata> mergeMetadata;
+    unique_ptr<TRestGeant4PhysicsLists> mergePhysicsLists;
 
     TRestRun mergeRun;
     mergeRun.SetName("run");
@@ -73,13 +97,31 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
                              // (because of sub-events) they keep the same event id after modification
         TRestRun run(inputFiles[i].c_str());
         auto metadata = dynamic_cast<TRestGeant4Metadata*>(run.GetMetadataClass("TRestGeant4Metadata"));
+        auto physicsLists =
+            dynamic_cast<TRestGeant4PhysicsLists*>(run.GetMetadataClass("TRestGeant4PhysicsLists"));
+        if (metadata == nullptr || physicsLists == nullptr) {
+            cerr << "ERROR: input file '" << inputFiles[i]
+                 << "' does not contain both TRestGeant4Metadata and TRestGeant4PhysicsLists" << endl;
+            exit(1);
+        }
         if (i == 0) {
-            mergeMetadata = *metadata;
+            mergeMetadata.reset(dynamic_cast<TRestGeant4Metadata*>(metadata->Clone()));
+            mergePhysicsLists.reset(dynamic_cast<TRestGeant4PhysicsLists*>(physicsLists->Clone()));
+            if (mergeMetadata == nullptr || mergePhysicsLists == nullptr) {
+                cerr << "ERROR: unable to clone simulation metadata from first input file" << endl;
+                exit(1);
+            }
         } else {
-            mergeMetadata.Merge(*metadata);
+            ValidateInputCompatibility(inputFiles[i], *mergeMetadata, *mergePhysicsLists, *metadata,
+                                       *physicsLists);
+            mergeMetadata->Merge(*metadata);
         }
         TRestGeant4Event* event = nullptr;
         auto eventTree = run.GetEventTree();
+        if (eventTree == nullptr) {
+            cerr << "ERROR: input file '" << inputFiles[i] << "' does not contain an EventTree" << endl;
+            exit(1);
+        }
         eventTree->SetBranchAddress("TRestGeant4EventBranch", &event);
         for (int j = 0; j < eventTree->GetEntries(); j++) {
             eventTree->GetEntry(j);
@@ -117,10 +159,15 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
 
     mergeRun.GetOutputFile()->cd();
 
+    if (gGeoManager == nullptr) {
+        cerr << "ERROR: input files did not provide a geometry manager" << endl;
+        exit(1);
+    }
     gGeoManager->Write("Geometry", TObject::kOverwrite);
 
-    mergeMetadata.SetName("geant4Metadata");
-    mergeMetadata.Write();
+    mergeMetadata->SetName("geant4Metadata");
+    mergeRun.AddMetadata(mergeMetadata.get());
+    mergeRun.AddMetadata(mergePhysicsLists.get());
     mergeRun.UpdateOutputFile();
     mergeRun.CloseFile();
 
@@ -129,6 +176,28 @@ void REST_Geant4_MergeRestG4Files(const char* outputFilename, const char* inputF
     if (runCheck.GetEntries() != eventCounter) {
         cerr << "ERROR: number of events in the output file (" << runCheck.GetEntries()
              << ") does not match the number of events in the input files (" << eventCounter << ")" << endl;
+        exit(1);
+    }
+    const auto mergedMetadata =
+        dynamic_cast<TRestGeant4Metadata*>(runCheck.GetMetadataClass("TRestGeant4Metadata"));
+    const auto mergedPhysicsLists =
+        dynamic_cast<TRestGeant4PhysicsLists*>(runCheck.GetMetadataClass("TRestGeant4PhysicsLists"));
+    if (mergedMetadata == nullptr || mergedPhysicsLists == nullptr) {
+        cerr << "ERROR: merged output did not preserve simulation and physics-list metadata" << endl;
+        exit(1);
+    }
+    if (mergedMetadata->GetNumberOfSources() != mergeMetadata->GetNumberOfSources()) {
+        cerr << "ERROR: merged output did not preserve particle-source metadata" << endl;
+        exit(1);
+    }
+    if (mergedMetadata->GetGeant4Version() != mergeMetadata->GetGeant4Version()) {
+        cerr << "ERROR: merged output did not preserve the Geant4 version metadata" << endl;
+        exit(1);
+    }
+    string physicsListsDifference;
+    if (!mergedPhysicsLists->IsEquivalentTo(*mergePhysicsLists, &physicsListsDifference)) {
+        cerr << "ERROR: merged output did not preserve TRestGeant4PhysicsLists: "
+             << physicsListsDifference << endl;
         exit(1);
     }
     cout << "Number of events in the output file: " << runCheck.GetEntries() << " matches internal count"

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -760,6 +760,9 @@
 #include <TRestGDMLParser.h>
 #include <TRestRun.h>
 
+#include <memory>
+#include <stdexcept>
+
 #include "TRestGeant4ParticleSourceCosmics.h"
 #include "TRestGeant4PrimaryGeneratorInfo.h"
 
@@ -1729,6 +1732,11 @@ void TRestGeant4Metadata::Merge(const TRestGeant4Metadata& metadata) {
     fIsMerge = true;
     fSeed = 0;  // seed makes no sense in a merged file
 
+    string physicsInfoConflict;
+    if (!fGeant4PhysicsInfo.Merge(metadata.fGeant4PhysicsInfo, &physicsInfoConflict)) {
+        throw runtime_error("Unable to merge TRestGeant4PhysicsInfo: " + physicsInfoConflict);
+    }
+
     fNEvents += metadata.fNEvents;
     fNRequestedEntries += metadata.fNRequestedEntries;
     fSimulationTime += metadata.fSimulationTime;
@@ -1739,6 +1747,38 @@ TRestGeant4Metadata::TRestGeant4Metadata(const TRestGeant4Metadata& metadata) : 
 }
 
 TRestGeant4Metadata& TRestGeant4Metadata::operator=(const TRestGeant4Metadata& metadata) {
+    if (this == &metadata) return *this;
+
+    // Particle sources are owned polymorphic pointers. A shallow copy makes
+    // both metadata objects delete the same sources, while omitting the copy
+    // silently drops the generator configuration from merged metadata. ROOT's
+    // Clone uses the concrete class streamer, preserving derived source types
+    // and their persistent configuration without copying transient resources.
+    vector<unique_ptr<TRestGeant4ParticleSource>> particleSources;
+    particleSources.reserve(metadata.fParticleSource.size());
+    for (const auto* source : metadata.fParticleSource) {
+        if (source == nullptr) {
+            particleSources.emplace_back(nullptr);
+            continue;
+        }
+
+        auto clone = unique_ptr<TRestGeant4ParticleSource>(
+            dynamic_cast<TRestGeant4ParticleSource*>(source->Clone()));
+        if (clone == nullptr) {
+            throw runtime_error("Unable to clone TRestGeant4ParticleSource while copying metadata");
+        }
+        particleSources.push_back(std::move(clone));
+    }
+
+    RemoveParticleSources();
+
+    SetName(metadata.GetName());
+    SetTitle(metadata.GetTitle());
+    fConfigFileName = metadata.fConfigFileName;
+    fSectionName = metadata.fSectionName;
+    configBuffer = metadata.configBuffer;
+    messageBuffer = metadata.messageBuffer;
+
     fIsMerge = metadata.fIsMerge;
     fGeant4GeometryInfo = metadata.fGeant4GeometryInfo;
     fGeant4PhysicsInfo = metadata.fGeant4PhysicsInfo;
@@ -1750,7 +1790,8 @@ TRestGeant4Metadata& TRestGeant4Metadata::operator=(const TRestGeant4Metadata& m
     fActiveVolumes = metadata.fActiveVolumes;
     fChance = metadata.fChance;
     fMaxStepSize = metadata.fMaxStepSize;
-    // fParticleSource = metadata.fParticleSource; // segfaults (pointers!)
+    fParticleSource.reserve(particleSources.size());
+    for (auto& source : particleSources) fParticleSource.push_back(source.release());
     fNBiasingVolumes = metadata.fNBiasingVolumes;
     fBiasingVolumes = metadata.fBiasingVolumes;
     fMaxTargetStepSize = metadata.fMaxTargetStepSize;
@@ -1758,13 +1799,16 @@ TRestGeant4Metadata& TRestGeant4Metadata::operator=(const TRestGeant4Metadata& m
     fResetTimePrecision = metadata.fResetTimePrecision;
     fResetGlobalTime = metadata.fResetGlobalTime;
     fFullChain = metadata.fFullChain;
+    fFullChainStopIsotopes = metadata.fFullChainStopIsotopes;
     fSensitiveVolumes = metadata.fSensitiveVolumes;
     fNEvents = metadata.fNEvents;
     fNRequestedEntries = metadata.fNRequestedEntries;
     fStoreTracks = metadata.fStoreTracks;
     fSimulationMaxTimeSeconds = metadata.fSimulationMaxTimeSeconds;
+    fSimulationTime = metadata.fSimulationTime;
     fSeed = metadata.fSeed;
     fSaveAllEvents = metadata.fSaveAllEvents;
+    fStoreHadronicTargetInfo = metadata.fStoreHadronicTargetInfo;
     fRemoveUnwantedTracks = metadata.fRemoveUnwantedTracks;
     fRemoveUnwantedTracksKeepZeroEnergyTracks = metadata.fRemoveUnwantedTracksKeepZeroEnergyTracks;
     fRemoveUnwantedTracksVolumesToKeep = metadata.fRemoveUnwantedTracksVolumesToKeep;

--- a/src/TRestGeant4Metadata.cxx
+++ b/src/TRestGeant4Metadata.cxx
@@ -1762,8 +1762,8 @@ TRestGeant4Metadata& TRestGeant4Metadata::operator=(const TRestGeant4Metadata& m
             continue;
         }
 
-        auto clone = unique_ptr<TRestGeant4ParticleSource>(
-            dynamic_cast<TRestGeant4ParticleSource*>(source->Clone()));
+        auto clone =
+            unique_ptr<TRestGeant4ParticleSource>(dynamic_cast<TRestGeant4ParticleSource*>(source->Clone()));
         if (clone == nullptr) {
             throw runtime_error("Unable to clone TRestGeant4ParticleSource while copying metadata");
         }

--- a/src/TRestGeant4PhysicsInfo.cxx
+++ b/src/TRestGeant4PhysicsInfo.cxx
@@ -104,3 +104,56 @@ Int_t TRestGeant4PhysicsInfo::GetParticleID(const TString& processName) const {
 TString TRestGeant4PhysicsInfo::GetProcessType(const TString& processName) const {
     return GetOrDefaultMapValueFromKey<TString, TString>(&fProcessTypesMap, processName);
 }
+
+bool TRestGeant4PhysicsInfo::Merge(const TRestGeant4PhysicsInfo& other, string* conflictReason) {
+    const auto setConflict = [&](const string& message) {
+        if (conflictReason != nullptr) {
+            *conflictReason = message;
+        }
+    };
+
+    for (const auto& [id, name] : other.fProcessNamesMap) {
+        if (fProcessNamesMap.count(id) > 0 && fProcessNamesMap.at(id) != name) {
+            setConflict("process id " + to_string(id) + " maps to both '" +
+                        string(fProcessNamesMap.at(id)) + "' and '" + string(name) + "'");
+            return false;
+        }
+    }
+    for (const auto& [name, id] : other.fProcessNamesReverseMap) {
+        if (fProcessNamesReverseMap.count(name) > 0 && fProcessNamesReverseMap.at(name) != id) {
+            setConflict("process '" + string(name) + "' maps to both id " +
+                        to_string(fProcessNamesReverseMap.at(name)) + " and id " + to_string(id));
+            return false;
+        }
+    }
+    for (const auto& [name, type] : other.fProcessTypesMap) {
+        if (fProcessTypesMap.count(name) > 0 && fProcessTypesMap.at(name) != type) {
+            setConflict("process '" + string(name) + "' maps to both type '" +
+                        string(fProcessTypesMap.at(name)) + "' and type '" + string(type) + "'");
+            return false;
+        }
+    }
+    for (const auto& [id, name] : other.fParticleNamesMap) {
+        if (fParticleNamesMap.count(id) > 0 && fParticleNamesMap.at(id) != name) {
+            setConflict("particle id " + to_string(id) + " maps to both '" +
+                        string(fParticleNamesMap.at(id)) + "' and '" + string(name) + "'");
+            return false;
+        }
+    }
+    for (const auto& [name, id] : other.fParticleNamesReverseMap) {
+        if (fParticleNamesReverseMap.count(name) > 0 && fParticleNamesReverseMap.at(name) != id) {
+            setConflict("particle '" + string(name) + "' maps to both id " +
+                        to_string(fParticleNamesReverseMap.at(name)) + " and id " + to_string(id));
+            return false;
+        }
+    }
+
+    lock_guard<mutex> lock(insertMutex);
+    fProcessNamesMap.insert(other.fProcessNamesMap.begin(), other.fProcessNamesMap.end());
+    fProcessNamesReverseMap.insert(other.fProcessNamesReverseMap.begin(), other.fProcessNamesReverseMap.end());
+    fProcessTypesMap.insert(other.fProcessTypesMap.begin(), other.fProcessTypesMap.end());
+    fParticleNamesMap.insert(other.fParticleNamesMap.begin(), other.fParticleNamesMap.end());
+    fParticleNamesReverseMap.insert(other.fParticleNamesReverseMap.begin(), other.fParticleNamesReverseMap.end());
+
+    return true;
+}

--- a/src/TRestGeant4PhysicsInfo.cxx
+++ b/src/TRestGeant4PhysicsInfo.cxx
@@ -114,8 +114,8 @@ bool TRestGeant4PhysicsInfo::Merge(const TRestGeant4PhysicsInfo& other, string* 
 
     for (const auto& [id, name] : other.fProcessNamesMap) {
         if (fProcessNamesMap.count(id) > 0 && fProcessNamesMap.at(id) != name) {
-            setConflict("process id " + to_string(id) + " maps to both '" +
-                        string(fProcessNamesMap.at(id)) + "' and '" + string(name) + "'");
+            setConflict("process id " + to_string(id) + " maps to both '" + string(fProcessNamesMap.at(id)) +
+                        "' and '" + string(name) + "'");
             return false;
         }
     }
@@ -150,10 +150,12 @@ bool TRestGeant4PhysicsInfo::Merge(const TRestGeant4PhysicsInfo& other, string* 
 
     lock_guard<mutex> lock(insertMutex);
     fProcessNamesMap.insert(other.fProcessNamesMap.begin(), other.fProcessNamesMap.end());
-    fProcessNamesReverseMap.insert(other.fProcessNamesReverseMap.begin(), other.fProcessNamesReverseMap.end());
+    fProcessNamesReverseMap.insert(other.fProcessNamesReverseMap.begin(),
+                                   other.fProcessNamesReverseMap.end());
     fProcessTypesMap.insert(other.fProcessTypesMap.begin(), other.fProcessTypesMap.end());
     fParticleNamesMap.insert(other.fParticleNamesMap.begin(), other.fParticleNamesMap.end());
-    fParticleNamesReverseMap.insert(other.fParticleNamesReverseMap.begin(), other.fParticleNamesReverseMap.end());
+    fParticleNamesReverseMap.insert(other.fParticleNamesReverseMap.begin(),
+                                    other.fParticleNamesReverseMap.end());
 
     return true;
 }

--- a/src/TRestGeant4PhysicsLists.cxx
+++ b/src/TRestGeant4PhysicsLists.cxx
@@ -138,6 +138,58 @@ Bool_t TRestGeant4PhysicsLists::PhysicsListExists(const TString& physicsListName
     return validPhysicsLists.count(physicsListName) > 0;
 }
 
+Bool_t TRestGeant4PhysicsLists::IsEquivalentTo(const TRestGeant4PhysicsLists& other,
+                                               string* difference) const {
+    const auto setDifference = [&](const string& message) {
+        if (difference != nullptr) {
+            *difference = message;
+        }
+    };
+
+    if (fPhysicsLists != other.fPhysicsLists) {
+        setDifference("physics-list names differ");
+        return false;
+    }
+    if (fPhysicsListOptions != other.fPhysicsListOptions) {
+        setDifference("physics-list options differ");
+        return false;
+    }
+    if (fCutForElectron != other.fCutForElectron) {
+        setDifference("electron production cuts differ");
+        return false;
+    }
+    if (fCutForGamma != other.fCutForGamma) {
+        setDifference("gamma production cuts differ");
+        return false;
+    }
+    if (fCutForPositron != other.fCutForPositron) {
+        setDifference("positron production cuts differ");
+        return false;
+    }
+    if (fCutForMuon != other.fCutForMuon) {
+        setDifference("muon production cuts differ");
+        return false;
+    }
+    if (fCutForNeutron != other.fCutForNeutron) {
+        setDifference("neutron production cuts differ");
+        return false;
+    }
+    if (fMinEnergyRangeProductionCuts != other.fMinEnergyRangeProductionCuts) {
+        setDifference("minimum production-cut energy differs");
+        return false;
+    }
+    if (fMaxEnergyRangeProductionCuts != other.fMaxEnergyRangeProductionCuts) {
+        setDifference("maximum production-cut energy differs");
+        return false;
+    }
+    if (fIonLimitStepList != other.fIonLimitStepList) {
+        setDifference("ion step-limit lists differ");
+        return false;
+    }
+
+    return true;
+}
+
 void TRestGeant4PhysicsLists::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 

--- a/test/src/TRestGeant4Metadata.cxx
+++ b/test/src/TRestGeant4Metadata.cxx
@@ -1,5 +1,6 @@
 
 #include <TRestGeant4Metadata.h>
+#include <TRestGeant4PhysicsInfo.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -29,6 +30,64 @@ TEST(TRestGeant4Metadata, Default) {
     restGeant4Metadata.PrintMetadata();
 
     EXPECT_TRUE(restGeant4Metadata.GetSeed() == 0);
+}
+
+TEST(TRestGeant4Metadata, CopyPreservesParticleSources) {
+    TRestGeant4Metadata original;
+    auto source = new TRestGeant4ParticleSource();
+    source->SetName("Fe55 source");
+    source->SetParticleName("Fe55");
+    source->SetEnergy(5.9);
+    source->SetEnergyDistributionRange(TVector2(5.8, 6.0));
+    original.AddParticleSource(source);
+
+    TRestGeant4Metadata copy(original);
+    ASSERT_EQ(copy.GetNumberOfSources(), 1);
+    EXPECT_NE(copy.GetParticleSource(), original.GetParticleSource());
+    EXPECT_EQ(copy.GetParticleSource()->GetParticleName(), "Fe55");
+    EXPECT_DOUBLE_EQ(copy.GetParticleSource()->GetEnergy(), 5.9);
+    EXPECT_DOUBLE_EQ(copy.GetParticleSource()->GetEnergyDistributionRangeMin(), 5.8);
+
+    TRestGeant4Metadata assigned;
+    assigned = original;
+    ASSERT_EQ(assigned.GetNumberOfSources(), 1);
+    EXPECT_NE(assigned.GetParticleSource(), original.GetParticleSource());
+    EXPECT_EQ(assigned.GetParticleSource()->GetParticleName(), "Fe55");
+
+    original.GetParticleSource()->SetEnergy(6.5);
+    EXPECT_DOUBLE_EQ(copy.GetParticleSource()->GetEnergy(), 5.9);
+    EXPECT_DOUBLE_EQ(assigned.GetParticleSource()->GetEnergy(), 5.9);
+}
+
+TEST(TRestGeant4PhysicsInfo, MergeKeepsLookupEntries) {
+    TRestGeant4PhysicsInfo first;
+    first.InsertProcessName(1, "Transportation", "transportation");
+    first.InsertParticleName(22, "gamma");
+
+    TRestGeant4PhysicsInfo second;
+    second.InsertProcessName(2, "phot", "electromagnetic");
+    second.InsertParticleName(11, "e-");
+
+    string conflict;
+    EXPECT_TRUE(first.Merge(second, &conflict));
+    EXPECT_TRUE(conflict.empty());
+    EXPECT_EQ(first.GetProcessName(1), "Transportation");
+    EXPECT_EQ(first.GetProcessName(2), "phot");
+    EXPECT_EQ(first.GetParticleName(22), "gamma");
+    EXPECT_EQ(first.GetParticleName(11), "e-");
+}
+
+TEST(TRestGeant4PhysicsInfo, MergeRejectsConflictingLookupEntries) {
+    TRestGeant4PhysicsInfo first;
+    first.InsertProcessName(1, "Transportation", "transportation");
+
+    TRestGeant4PhysicsInfo second;
+    second.InsertProcessName(1, "phot", "electromagnetic");
+
+    string conflict;
+    EXPECT_FALSE(first.Merge(second, &conflict));
+    EXPECT_FALSE(conflict.empty());
+    EXPECT_EQ(first.GetProcessName(1), "Transportation");
 }
 
 TEST(TRestGeant4Metadata, FromRml) {


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Large: 298](https://badgen.net/badge/PR%20Size/Large%3A%20298/red) [![](https://github.com/rest-for-physics/geant4lib/actions/workflows/frameworkValidation.yml/badge.svg?branch=cris_fix_merge_metadata_validation)](https://github.com/rest-for-physics/geant4lib/commits/cris_fix_merge_metadata_validation) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Preserve and validate the Geant4 metadata required by `REST_Geant4_MergeRestG4Files`.

This PR addresses the metadata-safety part of restG4 simulation-output merging. It updates
`REST_Geant4_MergeRestG4Files.C` and related metadata classes so merged files preserve and validate the simulation metadata needed to interpret Geant4/restG4 outputs.

## Changes

- Deep-copy particle sources in `TRestGeant4Metadata`.
- Preserve `TRestGeant4PhysicsLists` in merged outputs.
- Validate Geant4 version and physics-list compatibility across inputs.
- Merge `TRestGeant4PhysicsInfo` lookup metadata with conflict checks.
- Add unit coverage for particle-source copy and physics-info merge.

## What this does not solve

This PR does not implement full `AnalysisTree` preservation/merge behavior from #114. That remains a separate design
decision because it affects duplicate event-ID handling and tree merge semantics.

If that behavior is implemented later, restG4 files with populated `AnalysisTree` objects could be merged more
completely through this macro. However, `TRestDataSet` is already intended to combine `AnalysisTree` data, so that
workflow should probably be prioritized unless maintainers decide otherwise.